### PR TITLE
Parallel download support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Changelog
 
-## [0.4.0](https://github.com/asfadmin/Discovery-asf_search/compare/v0.3.0...v0.3.0)
+## [0.4.1](https://github.com/asfadmin/Discovery-asf_search/compare/v0.4.0...v0.4.1)
+### Added
+- Parallel downloads now supported by ASFSearchResults. Defaults to 1 (sequential download)
+
+### Changed
+- Import download functionality in asf_search (for `download_url()`)
+
+### Fixed
+- Fixed ASFProduct import in search.py
+
+## [0.4.0](https://github.com/asfadmin/Discovery-asf_search/compare/v0.3.0...v0.4.0)
 ### Added
 - ASFSearchResults now has a geojson() method which returns a data structure that matches the geojson specification
 - ASFProduct now has a geojson() method that produces a data structure matching a geojson feature snippet

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.3.2](https://github.com/asfadmin/Discovery-asf_search/compare/v0.2.4...v0.3.2)
+## [0.3.1](https://github.com/asfadmin/Discovery-asf_search/compare/v0.2.4...v0.3.1)
 
 ### Added
 - Layed out framework for INSTRUMENT constants (needs to be populated)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,7 @@
 # Changelog
 
-## [0.3.1](https://github.com/asfadmin/Discovery-asf_search/compare/v0.2.4...v0.3.1)
-
+## [0.4.0](https://github.com/asfadmin/Discovery-asf_search/compare/v0.3.0...v0.3.0)
 ### Added
-- Layed out framework for INSTRUMENT constants (needs to be populated)
-- Support for baseline stacking of pre-calculated datasets
-- Download support for single products or entire search result sets, token-based auth only
-- ASFSearchResults and ASFProduct classes
-- Lower-level ASFError exception class
-- ASFDownloadError exception class
-- ASFBaselineError exception class
-- Better path/frame/platform/product example
 - ASFSearchResults now has a geojson() method which returns a data structure that matches the geojson specification
 - ASFProduct now has a geojson() method that produces a data structure matching a geojson feature snippet
 - ASFSearchResults and ASFProduct both have a __str__() methods that serializes the output of their geojson() methods
@@ -23,6 +14,27 @@
     - offNadirAngle
     - season
 
+### Changed
+- ASFProduct is no longer a subclass of dict. Instead, metadata has been moved to .properties and .geometry
+- ASFSearchResults is now a subclass of UserList, for list-type operations
+- Newly-built stacks are sorted by temporal baselines, ascending
+
+### Fixed
+- Cleaned up cruft from various refactors
+
+
+## [0.3.0](https://github.com/asfadmin/Discovery-asf_search/compare/v0.2.4...v0.3.0)
+
+### Added
+- Layed out framework for INSTRUMENT constants (needs to be populated)
+- Support for baseline stacking of pre-calculated datasets
+- Download support for single products or entire search result sets, token-based auth only
+- ASFSearchResults and ASFProduct classes
+- Lower-level ASFError exception class
+- ASFDownloadError exception class
+- ASFBaselineError exception class
+- Better path/frame/platform/product example
+
 
 ### Changed
 - No longer uses range type for parameters that accept lists of values and/or ranges. Now expects a 2-value tuple.
@@ -32,15 +44,11 @@
 - insarStackID now a search option (needed for baseline stacking of pre-calculated datasets)
 - Flatter structure for constants
 - baseline functionality moved into search group (file restructuring)
-- ASFProduct is no longer a subclass of dict. Instead, metadata has been moved to .properties and .geometry
-- ASFSearchResults is now a subclass of UserList, for list-type operations
-- Newly-built stacks are sorted by temporal baselines, ascending
 
 ### Fixed
 - Corrected handling of version number in user agent string
 - unused import cleanup
 - better type hinting on centroid() function
-- Cleaned up cruft from various refactors
 
 ## [0.2.4](https://github.com/asfadmin/Discovery-asf_search/compare/v0.0.0...v0.2.4)
 

--- a/asf_search/ASFSearchResults.py
+++ b/asf_search/ASFSearchResults.py
@@ -1,7 +1,6 @@
 from collections import UserList
+from multiprocessing import Pool
 import json
-
-from asf_search.ASFProduct import ASFProduct
 
 
 class ASFSearchResults(UserList):
@@ -14,15 +13,29 @@ class ASFSearchResults(UserList):
     def __str__(self):
         return json.dumps(self.geojson(), indent=2, sort_keys=True)
 
-    def download(self, dir: str, token: str = None) -> None:
+    def download(self, dir: str, token: str = None, parallel=1) -> None:
         """
         Iterates over each ASFProduct and downloads them to the specified directory.
 
         :param dir: The directory into which the products should be downloaded.
         :param token: EDL authentication token for authenticated downloads, see https://urs.earthdata.nasa.gov/user_tokens
+        :param parallel: Number of parallel downloads to use. Defaults to 1 (i.e. sequential download)
 
         :return: None
         """
 
-        for product in self:
-            product.download(dir=dir, token=token)
+        if parallel == 1:
+            for product in self:
+                product.download(dir=dir, token=token)
+        else:
+            pool = Pool(processes=parallel)
+            args = [(product, dir, token) for product in self]
+            pool.map(_download_product, args)
+            pool.close()
+            pool.join()
+
+
+def _download_product(args):
+    product, dir, token = args
+    product.download(dir=dir, token=token)
+

--- a/asf_search/__init__.py
+++ b/asf_search/__init__.py
@@ -6,6 +6,7 @@ from .exceptions import *
 from .constants import *
 from .health import *
 from .search import *
+from .download import *
 
 try:
     __version__ = version(__name__)

--- a/asf_search/search/search.py
+++ b/asf_search/search/search.py
@@ -5,7 +5,8 @@ import datetime
 import math
 from importlib.metadata import PackageNotFoundError, version
 
-from asf_search.ASFSearchResults import ASFSearchResults, ASFProduct
+from asf_search.ASFSearchResults import ASFSearchResults
+from asf_search.ASFProduct import ASFProduct
 from asf_search.exceptions import ASFSearch4xxError, ASFSearch5xxError, ASFServerError
 from asf_search.constants import INTERNAL
 


### PR DESCRIPTION
### Added
- Parallel downloads now supported by ASFSearchResults. Defaults to 1 (sequential download)

### Changed
- Import download functionality in asf_search (for `download_url()`)

### Fixed
- Fixed ASFProduct import in search.py