### PR TITLE
imporlib_metdata fixes for python < 3.8

### DIFF
--- a/asf_search/__init__.py
+++ b/asf_search/__init__.py
@@ -1,4 +1,5 @@
-from importlib.metadata import PackageNotFoundError, version
+# backport of importlib.metadata for python < 3.8
+from importlib_metadata import PackageNotFoundError, version
 
 from .ASFProduct import ASFProduct
 from .ASFSearchResults import ASFSearchResults

--- a/asf_search/download/download.py
+++ b/asf_search/download/download.py
@@ -1,8 +1,8 @@
 import os.path
 import urllib.parse
 import requests
-from importlib.metadata import PackageNotFoundError, version
 
+from asf_search import __version__
 from asf_search.exceptions import ASFDownloadError
 
 
@@ -25,11 +25,7 @@ def download_url(url: str, dir: str, filename: str = None, token: str = None) ->
     if os.path.isfile(os.path.join(dir, filename)):
         raise ASFDownloadError(f'File already exists: {os.path.join(dir, filename)}')
 
-    try:
-        pkg_version = version(__name__)
-    except PackageNotFoundError:
-        pkg_version = '0.0.0'
-    headers = {'User-Agent': f'{__name__}.{pkg_version}'}
+    headers = {'User-Agent': f'{__name__}.{__version__}'}
     if token is not None:
         headers['Authorization'] = f'Bearer {token}'
 

--- a/asf_search/search/search.py
+++ b/asf_search/search/search.py
@@ -3,8 +3,8 @@ import requests
 from requests.exceptions import HTTPError
 import datetime
 import math
-from importlib.metadata import PackageNotFoundError, version
 
+from asf_search import __version__
 from asf_search.ASFSearchResults import ASFSearchResults
 from asf_search.ASFProduct import ASFProduct
 from asf_search.exceptions import ASFSearch4xxError, ASFSearch5xxError, ASFServerError
@@ -116,12 +116,7 @@ def search(
 
     data['output'] = 'geojson'
 
-    try:
-        pkg_version = version(__name__)
-    except PackageNotFoundError:
-        pkg_version = '0.0.0'
-    headers = {'User-Agent': f'{__name__}.{pkg_version}'}
-
+    headers = {'User-Agent': f'{__name__}.{__version__}'}
     response = requests.post(f'https://{host}{INTERNAL.SEARCH_PATH}', data=data, headers=headers)
 
     try:

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,8 @@ requirements = [
         "requests",
         "numpy",
         "python-dateutil",
-        "pytz"
+        "pytz",
+        "importlib_metadata",
     ]
 
 with open("README.md", "r") as readme_file:


### PR DESCRIPTION
`importlib.metadata` is only available for python 3.8+, but the `importlib_metadata` package backports the functionality for python <3.8.

This will fix `asf_search` for python <3.8. 

I've also made it so the package version only needs to be resolved once, but **I've removed** setting a default version to `0.0.0` so the package will *have to be installed* if cloned directly (via `python -m pip install -e .`). I think this is preferable, personally, as you'll always get the right package version in your headers, but it does require developers to install the package.

Previous functionality could be restored by issuing a `UserWarning` with the currently printed message and setting `__version__ = 0.0.0' during exception handling if desired. 
https://github.com/asfadmin/Discovery-asf_search/blob/importlib-metadata/asf_search/__init__.py#L14-L19

---

fixes #29 

