### PR TITLE
Feature auth download - Cookies, user/pass supported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,21 @@
 
 ## [3.0.0](https://github.com/asfadmin/Discovery-asf_search/compare/v2.0.2...v3.0.0)
 ### Added
-- Auth support for cookiejars, and user/pass combos. Create them as sessions, then pass the session to the appropeate method.
-    - Added `get_session_creds`, `get_session_token`, and `get_session_cookies`.
+- Auth support for username/password and cookiejars, in addition to the previously available token-based approach. Create a session, authenticate it with the method of choice, then pass the session to whichever download method is being used.
+    - Sessions can be created using the `ASFSession` class, a subclass of `requests.Session`
+    - Once a session is created, call one of its authentication methods:
+      - `auth_with_creds('user', 'pass)`
+      - `auth_with_token(`EDL token`)
+      - `auth_with_cookiejar(http.cookiejar)`
+    - If you were previously using the `token` argument, such as:
+      - `results.download(path='...', token='EDL token')`
+    - Updating can be as simple as:
+      - `results.download(path='...', session=ASFSession().auth_with_token('EDL token'))`
+    - Sessions can be re-used and are thread-safe
 
 ### Changed
-- Switched from accepting the param `token`, to `session` (for `download_url()` and `download_urls()`)
-- Sends auth headers to everywhere (now including AWS)
+- `download_url()`, `download_urls()`, `ASFProduct.download()` and `ASFSearchResults.download()` now expect a `session` argument instead of `token`
+- Send auth headers to every step along a download redirect chain (including final AWS S3 buckets)
 
 ## [2.0.2](https://github.com/asfadmin/Discovery-asf_search/compare/v2.0.1...v2.0.2)
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [3.0.0](https://github.com/asfadmin/Discovery-asf_search/compare/v2.0.2...v3.0.0)
+### Added
+- Auth support for cookiejars, and user/pass combos. Create them as sessions, then pass the session to the appropeate method.
+    - Added `get_session_creds`, `get_session_token`, and `get_session_cookies`.
+
+### Changed
+- Switched from accepting the param `token`, to `session` (for `download_url()` and `download_urls()`)
+- Sends auth headers to everywhere (now including AWS)
+
 ## [2.0.2](https://github.com/asfadmin/Discovery-asf_search/compare/v2.0.1...v2.0.2)
 ### Added
 - INSTRUMENT constants for C-SAR, PALSAR, and ANVIR-2

--- a/README.md
+++ b/README.md
@@ -49,7 +49,27 @@ Programmatically searching for ASF data is made simple with asf_search. Several 
 - `stack()` Find a baseline stack of products using a reference scene
 - Additionally, numerous constants are provided to ease the search process
 
-Examples of all of the above can be found in `examples/`
+Additionally, asf_search support downloading data, both from search results as provided by the above search functions, and directly on product URLs. An authenticated session is generally required. This is provided by the `ASFSession` class, and use of one of its three authentication methods:
+- `auth_with_creds('user', 'pass)`
+- `auth_with_token('EDL token')`
+- `auth_with_cookiejar(http.cookiejar)`
+
+That session should be passed to whichever download method is being called, can be re-used, and is thread safe. Examples:
+```python
+results = asf_search.granule_search([...])
+session = asf_search.ASFSession()
+session.auth_with_creds('user', 'pass')
+results.download(path='/Users/SARGuru/data', session=session)
+```
+Alternately, downloading a list of URLs contained in `urls` and creating the session inline:
+```python
+urls = [...]
+asf_search.download_urls(urls=urls, path='/Users/SARGuru/data', session=ASFSession().auth_with_token('EDL token'))
+```
+
+Also note that `ASFSearchResults.download()` and the generic `download_urls()` function both accept a `processes` parameter which allows for parallel downloads.
+
+Further examples of all of the above can be found in `examples/`
 
 
 ## Development

--- a/asf_search/ASFProduct.py
+++ b/asf_search/ASFProduct.py
@@ -5,6 +5,7 @@ from collections import UserList
 import requests
 
 from asf_search.download import download_url
+from asf_search import ASFSession
 
 
 class ASFProduct:
@@ -22,13 +23,13 @@ class ASFProduct:
             'properties': self.properties
         }
 
-    def download(self, path: str, filename: str = None, session: requests.Session = None) -> None:
+    def download(self, path: str, filename: str = None, session: ASFSession = None) -> None:
         """
         Downloads this product to the specified path and optional filename.
 
         :param path: The directory into which this product should be downloaded.
         :param filename: Optional filename to use instead of the original filename of this product.
-        :param session: The session to use when downloading. This session should already be authenticated if that is required for the product in question. A blank session will be created if none is provided.
+        :param session: The session to use, in most cases should be authenticated beforehand
 
         :return: None
         """

--- a/asf_search/ASFProduct.py
+++ b/asf_search/ASFProduct.py
@@ -2,6 +2,7 @@ from typing import Iterable
 import numpy as np
 import json
 from collections import UserList
+import requests
 
 from asf_search.download import download_url
 
@@ -21,20 +22,20 @@ class ASFProduct:
             'properties': self.properties
         }
 
-    def download(self, path: str, filename: str = None, token: str = None) -> None:
+    def download(self, path: str, filename: str = None, session: requests.Session = None) -> None:
         """
         Downloads this product to the specified path and optional filename.
 
         :param path: The directory into which this product should be downloaded.
         :param filename: Optional filename to use instead of the original filename of this product.
-        :param token: EDL authentication token for authenticated downloads, see https://urs.earthdata.nasa.gov/user_tokens
+        :param session: The session to use when downloading. This session should already be authenticated if that is required for the product in question. A blank session will be created if none is provided.
 
         :return: None
         """
         if filename is None:
             filename = self.properties['fileName']
 
-        download_url(url=self.properties['url'], path=path, filename=filename, token=token)
+        download_url(url=self.properties['url'], path=path, filename=filename, session=session)
 
     def stack(self) -> UserList:
         """

--- a/asf_search/ASFSearchResults.py
+++ b/asf_search/ASFSearchResults.py
@@ -1,7 +1,7 @@
 from collections import UserList
 from multiprocessing import Pool
 import json
-import requests
+from asf_search import ASFSession
 
 
 class ASFSearchResults(UserList):
@@ -14,12 +14,12 @@ class ASFSearchResults(UserList):
     def __str__(self):
         return json.dumps(self.geojson(), indent=2, sort_keys=True)
 
-    def download(self, path: str, session: requests.Session = None, processes=1) -> None:
+    def download(self, path: str, session: ASFSession = None, processes=1) -> None:
         """
         Iterates over each ASFProduct and downloads them to the specified path.
 
         :param path: The directory into which the products should be downloaded.
-        :param session: The session to use when downloading. This session should already be authenticated if that is required for the product in question. A blank session will be created if none is provided.
+        :param session: The session to use, in most cases should be authenticated beforehand
         :param processes: Number of download processes to use. Defaults to 1 (i.e. sequential download)
 
         :return: None

--- a/asf_search/ASFSearchResults.py
+++ b/asf_search/ASFSearchResults.py
@@ -24,6 +24,8 @@ class ASFSearchResults(UserList):
 
         :return: None
         """
+        if session is None:
+            session = ASFSession()
 
         if processes == 1:
             for product in self:

--- a/asf_search/ASFSearchResults.py
+++ b/asf_search/ASFSearchResults.py
@@ -1,6 +1,7 @@
 from collections import UserList
 from multiprocessing import Pool
 import json
+import requests
 
 
 class ASFSearchResults(UserList):
@@ -13,12 +14,12 @@ class ASFSearchResults(UserList):
     def __str__(self):
         return json.dumps(self.geojson(), indent=2, sort_keys=True)
 
-    def download(self, path: str, token: str = None, processes=1) -> None:
+    def download(self, path: str, session: requests.Session = None, processes=1) -> None:
         """
         Iterates over each ASFProduct and downloads them to the specified path.
 
         :param path: The directory into which the products should be downloaded.
-        :param token: EDL authentication token for authenticated downloads, see https://urs.earthdata.nasa.gov/user_tokens
+        :param session: The session to use when downloading. This session should already be authenticated if that is required for the product in question. A blank session will be created if none is provided.
         :param processes: Number of download processes to use. Defaults to 1 (i.e. sequential download)
 
         :return: None
@@ -26,15 +27,15 @@ class ASFSearchResults(UserList):
 
         if processes == 1:
             for product in self:
-                product.download(path=path, token=token)
+                product.download(path=path, session=session)
         else:
             pool = Pool(processes=processes)
-            args = [(product, path, token) for product in self]
+            args = [(product, path, session) for product in self]
             pool.map(_download_product, args)
             pool.close()
             pool.join()
 
 
 def _download_product(args):
-    product, path, token = args
-    product.download(path=path, token=token)
+    product, path, session = args
+    product.download(path=path, session=session)

--- a/asf_search/ASFSession.py
+++ b/asf_search/ASFSession.py
@@ -37,7 +37,6 @@ class ASFSession(requests.Session):
 
         :return ASFSession: returns self for convenience
         """
-        # TODO: See if we can establish this session more completely so it works with non-token-supporting venues
         self.headers.update({'Authorization': 'Bearer {0}'.format(token)})
 
         return self

--- a/asf_search/ASFSession.py
+++ b/asf_search/ASFSession.py
@@ -1,0 +1,55 @@
+import requests
+import http.cookiejar
+from asf_search import __version__
+from asf_search.constants import EDL_CLIENT_ID, EDL_HOST, ASF_AUTH_HOST
+from asf_search.exceptions import ASFAuthenticationError
+
+
+class ASFSession(requests.Session):
+    def __init__(self):
+        super().__init__()
+        self.headers.update({'User-Agent': f'{__name__}.{__version__}'})
+
+    def auth_with_creds(self, username: str, password: str):
+        """
+        Authenticates the session using EDL username/password credentials
+
+        :param username: EDL username, see https://urs.earthdata.nasa.gov/
+        :param password: EDL password, see https://urs.earthdata.nasa.gov/
+
+        :return ASFSession: returns self for convenience
+        """
+        login_url = f'https://{EDL_HOST}/oauth/authorize?client_id={EDL_CLIENT_ID}&response_type=code&redirect_uri=https://{ASF_AUTH_HOST}/login'
+
+        self.auth = (username, password)
+        self.get(login_url)
+
+        if "urs_user_already_logged" not in self.cookies.get_dict():
+            raise ASFAuthenticationError("Username or password is incorrect")
+
+        return self
+
+    def auth_with_token(self, token: str):
+        """
+        Authenticates the session using an EDL Authorization: Bearer token
+
+        :param token: EDL Auth Token for authenticated downloads, see https://urs.earthdata.nasa.gov/user_tokens
+
+        :return ASFSession: returns self for convenience
+        """
+        # TODO: See if we can establish this session more completely so it works with non-token-supporting venues
+        self.headers.update({'Authorization': 'Bearer {0}'.format(token)})
+
+        return self
+
+    def auth_with_cookiejar(self, cookies: http.cookiejar):
+        """
+        Authenticates the session using a pre-existing cookiejar
+
+        :param cookies: Any http.cookiejar compatible object
+
+        :return ASFSession: returns self for convenience
+        """
+        self.cookies = cookies
+
+        return self

--- a/asf_search/__init__.py
+++ b/asf_search/__init__.py
@@ -12,6 +12,7 @@ except PackageNotFoundError:
 
 from .ASFProduct import ASFProduct
 from .ASFSearchResults import ASFSearchResults
+from .ASFSession import ASFSession
 from .exceptions import *
 from .constants import *
 from .health import *

--- a/asf_search/__init__.py
+++ b/asf_search/__init__.py
@@ -10,9 +10,9 @@ except PackageNotFoundError:
           'Or, to just get the version number use:\n'
           '   python setup.py --version')
 
+from .ASFSession import ASFSession
 from .ASFProduct import ASFProduct
 from .ASFSearchResults import ASFSearchResults
-from .ASFSession import ASFSession
 from .exceptions import *
 from .constants import *
 from .health import *

--- a/asf_search/constants/INTERNAL.py
+++ b/asf_search/constants/INTERNAL.py
@@ -1,7 +1,5 @@
-HOST = 'api.daac.asf.alaska.edu'
-HOST_TEST = 'api-test.asf.alaska.edu'
-HOST_DEV = 'api-dev.asf.alaska.edu'
-HOST_LOCAL = 'local.asf.alaska.edu:5000'
+SEARCH_API_HOST = 'api.daac.asf.alaska.edu'
+ASF_AUTH_HOST = 'auth.asf.alaska.edu'
 
 HEALTH_PATH = '/health'
 SEARCH_PATH = '/services/search/param'
@@ -10,4 +8,5 @@ MISSION_PATH = '/services/utils/mission_list'
 DATE_PATH = '/services/utils/date'
 
 CMR_HOST = 'cmr.earthdata.nasa.gov'
-CMR_HOST_UAT = 'cmr.uat.earthdata.nasa.gov'
+EDL_HOST = 'urs.earthdata.nasa.gov'
+EDL_CLIENT_ID = 'BO_n7nTIlMljdvU6kRRB3g'

--- a/asf_search/constants/__init__.py
+++ b/asf_search/constants/__init__.py
@@ -7,5 +7,3 @@ from .PLATFORM import *
 from .POLARIZATION import *
 from .PRODUCT_TYPE import *
 from .INTERNAL import *
-
-#TODO: add INSTRUMENT constants

--- a/asf_search/download/__init__.py
+++ b/asf_search/download/__init__.py
@@ -1,2 +1,1 @@
 from .download import download_urls, download_url
-from .download import get_session_creds, get_session_token, get_session_cookies

--- a/asf_search/download/__init__.py
+++ b/asf_search/download/__init__.py
@@ -1,1 +1,2 @@
 from .download import download_urls, download_url
+from .download import get_session_creds, get_session_token, get_session_cookies

--- a/asf_search/download/download.py
+++ b/asf_search/download/download.py
@@ -51,7 +51,7 @@ def get_session_cookies(cookies: http.cookiejar) -> requests.Session:
     :param cookies: Any http.cookiejar compatible object
     :return: requests.Session object
     """
-    session = requests.Session()
+    session = get_asf_session()
     session.cookies = cookies
     return session
 

--- a/asf_search/download/download.py
+++ b/asf_search/download/download.py
@@ -59,7 +59,7 @@ def _download_url(arg):
         session=session)
 
 
-def download_urls(urls: Iterable[str], path: str, session: requests.Session, processes: int = 1):
+def download_urls(urls: Iterable[str], path: str, session: requests.Session = None, processes: int = 1):
     pool = Pool(processes=processes)
     args = [(url, path, session) for url in urls]
     pool.map(_download_url, args)

--- a/asf_search/download/download.py
+++ b/asf_search/download/download.py
@@ -31,7 +31,7 @@ def get_session_token(token: str = "") -> requests.Session:
     """
     Gives a session, with the token pre-added.
 
-    :param token: EDL Auth Token for authenticating downloads, see https://urs.earthdata.nasa.gov/user_tokens
+    :param token: EDL Auth Token for authenticated downloads, see https://urs.earthdata.nasa.gov/user_tokens
     :return: session object
     """
     session = get_asf_session()

--- a/asf_search/download/download.py
+++ b/asf_search/download/download.py
@@ -7,6 +7,7 @@ import http.cookiejar
 
 from asf_search import __version__
 from asf_search.exceptions import ASFDownloadError
+from asf_search.constants import EDL_CLIENT_ID, EDL_HOST, ASF_AUTH_HOST
 
 
 def get_asf_session() -> requests.Session:
@@ -24,7 +25,7 @@ def get_session_creds(username: str, password: str) -> requests.Session:
     :return: requests.Session object
     """
     session = get_asf_session()
-    login_url = "https://urs.earthdata.nasa.gov/oauth/authorize?client_id=BO_n7nTIlMljdvU6kRRB3g&response_type=code&redirect_uri=https://auth.asf.alaska.edu/login"
+    login_url = f'https://{EDL_HOST}/oauth/authorize?client_id={EDL_CLIENT_ID}&response_type=code&redirect_uri=https://{ASF_AUTH_HOST}/login'
 
     session.auth = (username, password)
     session.get(login_url)

--- a/asf_search/download/download.py
+++ b/asf_search/download/download.py
@@ -40,7 +40,7 @@ def get_session_token(token: str) -> requests.Session:
 
 def get_session_cookies(cookies: Requests) -> requests.Session:
     """
-    Gives a session, with cookes added.
+    Gives a session, with cookies added.
 
     :param cookies: Any cookielib.CookieJar compatible object (Default RequestsCookieJar)
     :return: session object

--- a/asf_search/download/download.py
+++ b/asf_search/download/download.py
@@ -17,11 +17,11 @@ def get_asf_session() -> requests.Session:
 
 def get_session_creds(username: str, password: str) -> requests.Session:
     """
-    Gives a session, with username/password added to the headers.
+    Builds a session using EDL username/password credentials
 
-    :param username: The username to EDL
-    :param password: The password to EDL
-    :return: session object
+    :param username: EDL username, see https://urs.earthdata.nasa.gov/
+    :param password: EDL password, see https://urs.earthdata.nasa.gov/
+    :return: requests.Session object
     """
     session = get_asf_session()
     login_url = "https://urs.earthdata.nasa.gov/oauth/authorize?client_id=BO_n7nTIlMljdvU6kRRB3g&response_type=code&redirect_uri=https://auth.asf.alaska.edu/login"
@@ -33,10 +33,10 @@ def get_session_creds(username: str, password: str) -> requests.Session:
 
 def get_session_token(token: str) -> requests.Session:
     """
-    Gives a session, with the token pre-added.
+    Builds a session using an EDL Authorization: Bearer token
 
     :param token: EDL Auth Token for authenticated downloads, see https://urs.earthdata.nasa.gov/user_tokens
-    :return: session object
+    :return: requests.Session object
     """
     session = get_asf_session()
     session.headers.update({'Authorization': 'Bearer {0}'.format(token)})
@@ -45,10 +45,10 @@ def get_session_token(token: str) -> requests.Session:
 
 def get_session_cookies(cookies: http.cookiejar) -> requests.Session:
     """
-    Gives a session, with cookies added.
+    Builds a session using a pre-existing cookiejar
 
     :param cookies: Any http.cookiejar compatible object
-    :return: session object
+    :return: requests.Session object
     """
     session = requests.Session()
     session.cookies = cookies

--- a/asf_search/download/download.py
+++ b/asf_search/download/download.py
@@ -3,6 +3,7 @@ from multiprocessing import Pool
 import os.path
 import urllib.parse
 import requests
+import http.cookiejar
 
 from asf_search import __version__
 from asf_search.exceptions import ASFDownloadError
@@ -38,17 +39,18 @@ def get_session_token(token: str) -> requests.Session:
     session.headers.update({'Authorization': 'Bearer {0}'.format(token)})
     return session
 
-def get_session_cookies(cookies: Requests) -> requests.Session:
+
+def get_session_cookies(cookies: http.cookiejar) -> requests.Session:
     """
     Gives a session, with cookies added.
 
-    :param cookies: Any cookielib.CookieJar compatible object (Default RequestsCookieJar)
+    :param cookies: Any http.cookiejar compatible object
     :return: session object
     """
-    # With using cookies: https://stackoverflow.com/questions/29200357/requests-session-load-cookies-from-cookiejar
     session = requests.Session()
     session.cookies = cookies
     return session
+
 
 def _download_url(arg):
     url, path, session = arg

--- a/asf_search/download/download.py
+++ b/asf_search/download/download.py
@@ -47,8 +47,7 @@ def get_session_cookies(cookies: Requests) -> requests.Session:
     """
     # With using cookies: https://stackoverflow.com/questions/29200357/requests-session-load-cookies-from-cookiejar
     session = requests.Session()
-    if cookies is not None:
-        session.cookies = cookies
+    session.cookies = cookies
     return session
 
 def _download_url(arg):

--- a/asf_search/download/download.py
+++ b/asf_search/download/download.py
@@ -2,62 +2,9 @@ from typing import Iterable
 from multiprocessing import Pool
 import os.path
 import urllib.parse
-import requests
-import http.cookiejar
 
-from asf_search import __version__
-from asf_search.exceptions import ASFDownloadError, ASFAuthenticationError
-from asf_search.constants import EDL_CLIENT_ID, EDL_HOST, ASF_AUTH_HOST
-
-
-def get_asf_session() -> requests.Session:
-    session = requests.Session()
-    session.headers.update({'User-Agent': f'{__name__}.{__version__}'})
-    return session
-
-
-def get_session_creds(username: str, password: str) -> requests.Session:
-    """
-    Builds a session using EDL username/password credentials
-
-    :param username: EDL username, see https://urs.earthdata.nasa.gov/
-    :param password: EDL password, see https://urs.earthdata.nasa.gov/
-    :return: requests.Session object
-    """
-    session = get_asf_session()
-    login_url = f'https://{EDL_HOST}/oauth/authorize?client_id={EDL_CLIENT_ID}&response_type=code&redirect_uri=https://{ASF_AUTH_HOST}/login'
-
-    session.auth = (username, password)
-    session.get(login_url)
-
-    if "urs_user_already_logged" not in session.cookies.get_dict():
-        raise ASFAuthenticationError("Username password combo is incorrect")
-
-    return session
-
-
-def get_session_token(token: str) -> requests.Session:
-    """
-    Builds a session using an EDL Authorization: Bearer token
-
-    :param token: EDL Auth Token for authenticated downloads, see https://urs.earthdata.nasa.gov/user_tokens
-    :return: requests.Session object
-    """
-    session = get_asf_session()
-    session.headers.update({'Authorization': 'Bearer {0}'.format(token)})
-    return session
-
-
-def get_session_cookies(cookies: http.cookiejar) -> requests.Session:
-    """
-    Builds a session using a pre-existing cookiejar
-
-    :param cookies: Any http.cookiejar compatible object
-    :return: requests.Session object
-    """
-    session = get_asf_session()
-    session.cookies = cookies
-    return session
+from asf_search.exceptions import ASFDownloadError
+from asf_search import ASFSession
 
 
 def _download_url(arg):
@@ -68,22 +15,35 @@ def _download_url(arg):
         session=session)
 
 
-def download_urls(urls: Iterable[str], path: str, session: requests.Session = None, processes: int = 1):
-    pool = Pool(processes=processes)
-    args = [(url, path, session) for url in urls]
-    pool.map(_download_url, args)
-    pool.close()
-    pool.join()
+def download_urls(urls: Iterable[str], path: str, session: ASFSession = None, processes: int = 1):
+    """
+    Downloads all products from the specified URLs to the specified location.
+
+    :param urls: List of URLs from which to download
+    :param path: Local path in which to save the product
+    :param session: The session to use, in most cases should be authenticated beforehand
+    :param processes: Number of download processes to use. Defaults to 1 (i.e. sequential download)
+    :return:
+    """
+    if processes <= 1:
+        for url in urls:
+            download_url(url=url, path=path, session=session)
+    else:
+        pool = Pool(processes=processes)
+        args = [(url, path, session) for url in urls]
+        pool.map(_download_url, args)
+        pool.close()
+        pool.join()
 
 
-def download_url(url: str, path: str, filename: str = None, session: requests.Session = None) -> None:
+def download_url(url: str, path: str, filename: str = None, session: ASFSession = None) -> None:
     """
     Downloads a product from the specified URL to the specified location and (optional) filename.
 
     :param url: URL from which to download
     :param path: Local path in which to save the product
     :param filename: Optional filename to be used, extracted from the URL by default
-    :param session: The session to use, with headers attached. Defaults to get_asf_session().
+    :param session: The session to use, in most cases should be authenticated beforehand
     :return:
     """
     if filename is None:
@@ -96,7 +56,7 @@ def download_url(url: str, path: str, filename: str = None, session: requests.Se
         raise ASFDownloadError(f'File already exists: {os.path.join(path, filename)}')
 
     if session is None:
-        session = get_asf_session()
+        session = ASFSession()
 
     print(f'Following {url}')
     response = session.get(url, stream=True, allow_redirects=False)

--- a/asf_search/download/download.py
+++ b/asf_search/download/download.py
@@ -6,7 +6,7 @@ import requests
 import http.cookiejar
 
 from asf_search import __version__
-from asf_search.exceptions import ASFDownloadError
+from asf_search.exceptions import ASFDownloadError, ASFAuthenticationError
 from asf_search.constants import EDL_CLIENT_ID, EDL_HOST, ASF_AUTH_HOST
 
 
@@ -29,6 +29,10 @@ def get_session_creds(username: str, password: str) -> requests.Session:
 
     session.auth = (username, password)
     session.get(login_url)
+
+    if "urs_user_already_logged" not in session.cookies.get_dict():
+        raise ASFAuthenticationError("Username password combo is incorrect")
+
     return session
 
 

--- a/asf_search/download/download.py
+++ b/asf_search/download/download.py
@@ -25,6 +25,9 @@ def download_urls(urls: Iterable[str], path: str, session: ASFSession = None, pr
     :param processes: Number of download processes to use. Defaults to 1 (i.e. sequential download)
     :return:
     """
+    if session is None:
+        session = ASFSession()
+
     if processes <= 1:
         for url in urls:
             download_url(url=url, path=path, session=session)

--- a/asf_search/download/download.py
+++ b/asf_search/download/download.py
@@ -8,10 +8,12 @@ import http.cookiejar
 from asf_search import __version__
 from asf_search.exceptions import ASFDownloadError
 
+
 def get_asf_session() -> requests.Session:
     session = requests.Session()
     session.headers.update({'User-Agent': f'{__name__}.{__version__}'})
     return session
+
 
 def get_session_creds(username: str, password: str) -> requests.Session:
     """
@@ -27,6 +29,7 @@ def get_session_creds(username: str, password: str) -> requests.Session:
     session.auth = (username, password)
     session.get(login_url)
     return session
+
 
 def get_session_token(token: str) -> requests.Session:
     """

--- a/asf_search/download/download.py
+++ b/asf_search/download/download.py
@@ -12,7 +12,7 @@ def get_asf_session() -> requests.Session:
     session.headers.update({'User-Agent': f'{__name__}.{__version__}'})
     return session
 
-def get_session_creds(username: str = "", password: str = "") -> requests.Session:
+def get_session_creds(username: str, password: str) -> requests.Session:
     """
     Gives a session, with username/password added to the headers.
 
@@ -27,7 +27,7 @@ def get_session_creds(username: str = "", password: str = "") -> requests.Sessio
     session.get(login_url)
     return session
 
-def get_session_token(token: str = "") -> requests.Session:
+def get_session_token(token: str) -> requests.Session:
     """
     Gives a session, with the token pre-added.
 
@@ -38,7 +38,7 @@ def get_session_token(token: str = "") -> requests.Session:
     session.headers.update({'Authorization': 'Bearer {0}'.format(token)})
     return session
 
-def get_session_cookies(cookies = None) -> requests.Session:
+def get_session_cookies(cookies: Requests) -> requests.Session:
     """
     Gives a session, with cookes added.
 

--- a/asf_search/exceptions.py
+++ b/asf_search/exceptions.py
@@ -18,3 +18,6 @@ class ASFBaselineError(ASFSearchError):
 
 class ASFDownloadError(ASFError):
     """Base download-related Exception"""
+
+class ASFAuthenticationError(ASFError):
+    """Base download-related Exception"""

--- a/asf_search/health/health.py
+++ b/asf_search/health/health.py
@@ -12,5 +12,5 @@ def health(host: str = None) -> dict:
     """
 
     if host is None:
-        host = asf_search.INTERNAL.HOST
+        host = asf_search.INTERNAL.SEARCH_API_HOST
     return json.loads(requests.get(f'https://{host}{asf_search.INTERNAL.HEALTH_PATH}').text)

--- a/asf_search/search/baseline_search.py
+++ b/asf_search/search/baseline_search.py
@@ -41,7 +41,6 @@ def stack_from_product(
     stack.sort(key=lambda product: product.properties['temporalBaseline'])
 
 
-    #TODO: Calculate temporal baselines
     #TODO: Calculate perpendicular baselines
     #TODO: Add nearest neighbor finder
 
@@ -88,8 +87,7 @@ def get_stack_params(reference: ASFProduct) -> dict:
         if reference.properties['insarStackId'] not in [None, 'NA', 0, '0']:
             stack_params['insarStackId'] = reference.properties['insarStackId']
             return stack_params
-        else:
-            raise ASFBaselineError(f'Requested reference product needs a baseline stack ID but does not have one: {reference["properties"]["fileID"]}')
+        raise ASFBaselineError(f'Requested reference product needs a baseline stack ID but does not have one: {reference["properties"]["fileID"]}')
 
     # build a stack from scratch if it's a non-precalc dataset with state vectors
     if reference.properties['platform'] in [PLATFORM.SENTINEL1A, PLATFORM.SENTINEL1B]:
@@ -98,9 +96,12 @@ def get_stack_params(reference: ASFProduct) -> dict:
         stack_params['flightDirection'] = [reference.properties['flightDirection']]
         #stack_params['lookDirection'] = [ref_scene.properties['lookDirection']]
         stack_params['relativeOrbit'] = [int(reference.properties['pathNumber'])]  # path
-        if reference.properties['polarization'] in ['HH', 'HH+HV']: stack_params['polarization'] = ['HH','HH+HV']
-        elif reference.properties['polarization'] in ['VV', 'VV+VH']: stack_params['polarization'] = ['VV','VV+VH']
-        else: stack_params['polarization'] = [reference.properties['polarization']]
+        if reference.properties['polarization'] in ['HH', 'HH+HV']:
+            stack_params['polarization'] = ['HH','HH+HV']
+        elif reference.properties['polarization'] in ['VV', 'VV+VH']:
+            stack_params['polarization'] = ['VV','VV+VH']
+        else:
+            stack_params['polarization'] = [reference.properties['polarization']]
         ref_centroid = reference.centroid()
         stack_params['intersectsWith'] = f'POINT({ref_centroid[0]} {ref_centroid[1]})'
         return stack_params
@@ -125,4 +126,3 @@ def calc_temporal_baselines(reference: ASFProduct, stack: ASFSearchResults) -> N
         if secondary_time.tzinfo is None:
             secondary_time = pytz.utc.localize(secondary_time)
         secondary.properties['temporalBaseline'] = (secondary_time - reference_time).days
-

--- a/asf_search/search/baseline_search.py
+++ b/asf_search/search/baseline_search.py
@@ -20,7 +20,7 @@ precalc_platforms = [
 def stack_from_product(
         reference: ASFProduct,
         strategy = None,
-        host: str = INTERNAL.HOST,
+        host: str = INTERNAL.SEARCH_API_HOST,
         cmr_token: str = None,
         cmr_provider: str = None) -> ASFSearchResults:
     """
@@ -51,7 +51,7 @@ def stack_from_product(
 def stack_from_id(
         reference_id: str,
         strategy = None,
-        host: str = INTERNAL.HOST,
+        host: str = INTERNAL.SEARCH_API_HOST,
         cmr_token: str = None,
         cmr_provider: str = None) -> ASFSearchResults:
     """

--- a/asf_search/search/baseline_search.py
+++ b/asf_search/search/baseline_search.py
@@ -40,10 +40,6 @@ def stack_from_product(
     calc_temporal_baselines(reference, stack)
     stack.sort(key=lambda product: product.properties['temporalBaseline'])
 
-
-    #TODO: Calculate perpendicular baselines
-    #TODO: Add nearest neighbor finder
-
     return stack
 
 

--- a/asf_search/search/geo_search.py
+++ b/asf_search/search/geo_search.py
@@ -24,7 +24,7 @@ def geo_search(
         relativeOrbit: Iterable[Union[int, range]] = None,
         start: Union[datetime.datetime, str] = None,
         maxResults: int = None,
-        host: str = INTERNAL.HOST,
+        host: str = INTERNAL.SEARCH_API_HOST,
         cmr_token: str = None,
         cmr_provider: str = None
 ) -> ASFSearchResults:

--- a/asf_search/search/granule_search.py
+++ b/asf_search/search/granule_search.py
@@ -7,7 +7,7 @@ from asf_search.constants import INTERNAL
 
 def granule_search(
         granule_list: Iterable[str],
-        host: str = INTERNAL.HOST,
+        host: str = INTERNAL.SEARCH_API_HOST,
         cmr_token: str = None,
         cmr_provider: str = None
 ) -> ASFSearchResults:

--- a/asf_search/search/product_search.py
+++ b/asf_search/search/product_search.py
@@ -7,7 +7,7 @@ from asf_search.constants import INTERNAL
 
 def product_search(
         product_list: Iterable[str],
-        host: str = INTERNAL.HOST,
+        host: str = INTERNAL.SEARCH_API_HOST,
         cmr_token: str = None,
         cmr_provider: str = None
 ) -> ASFSearchResults:

--- a/asf_search/search/search.py
+++ b/asf_search/search/search.py
@@ -40,7 +40,7 @@ def search(
         season: Tuple[int, int] = None,
         start: Union[datetime.datetime, str] = None,
         maxResults: int = None,
-        host: str = INTERNAL.HOST,
+        host: str = INTERNAL.SEARCH_API_HOST,
         cmr_token: str = None,
         cmr_provider: str = None
 ) -> ASFSearchResults:


### PR DESCRIPTION
requests documentation says the .netrc file is loaded automatically, if you don't add auth yourself. (For us, just calling download_url without passing a session). I can't yet get it working with redirects, but we're close to that too.

I wrote a draft in the changelog, but it might be wordy. Feel free to edit it too if you notice anything.

Thanks!