### PR TITLE
Don't re-use established session if a download redirect goes direct to S3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [3.0.1](https://github.com/asfadmin/Discovery-asf_search/compare/v3.0.0...v3.0.1)
+### Fixed
+- Fix download authentication header issue during direct S3 redirects
+
 ## [3.0.0](https://github.com/asfadmin/Discovery-asf_search/compare/v2.0.2...v3.0.0)
 ### Added
 - Auth support for username/password and cookiejars, in addition to the previously available token-based approach. Create a session, authenticate it with the method of choice, then pass the session to whichever download method is being used.


### PR DESCRIPTION
Don't re-use established session if a download redirect goes direct to S3, just do a bare request. That way, we can still ensure thread safety since we won't need to mangle the session to get that redirect to work without S3 errors.