### PR TITLE
Use shapely to calculate centroid

### DIFF
--- a/asf_search/ASFProduct.py
+++ b/asf_search/ASFProduct.py
@@ -1,5 +1,4 @@
-from typing import Iterable
-import numpy as np
+from shapely.geometry import shape, Point
 import json
 from collections import UserList
 import requests
@@ -48,11 +47,8 @@ class ASFProduct:
 
         return stack_from_product(self)
 
-    def centroid(self) -> (Iterable[float]):
+    def centroid(self) -> Point:
         """
         Finds the centroid of a product
-        Shamelessly lifted from https://stackoverflow.com/a/23021198 and https://stackoverflow.com/a/57183264
         """
-        arr = np.array(self.geometry['coordinates'][0])
-        length, dim = arr.shape
-        return [np.sum(arr[:, i]) / length for i in range(dim)]
+        return shape(self.geometry).centroid

--- a/asf_search/search/baseline_search.py
+++ b/asf_search/search/baseline_search.py
@@ -98,8 +98,7 @@ def get_stack_params(reference: ASFProduct) -> dict:
             stack_params['polarization'] = ['VV','VV+VH']
         else:
             stack_params['polarization'] = [reference.properties['polarization']]
-        ref_centroid = reference.centroid()
-        stack_params['intersectsWith'] = f'POINT({ref_centroid[0]} {ref_centroid[1]})'
+        stack_params['intersectsWith'] = reference.centroid().wkt
         return stack_params
 
     raise ASFBaselineError(f'Reference product is not a pre-calculated baseline dataset, and not a known ephemeris-based dataset: {reference.properties["fileID"]}')

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import subprocess
 
 requirements = [
         "requests",
-        "numpy",
+        "shapely",
         "python-dateutil",
         "pytz",
         "importlib_metadata",


### PR DESCRIPTION
I was getting different results back from `asf_search.baseline_search` vs in Vertex and it appears to have come down to the way  `ASFProduct.centroid` is calculated. Examples:

![image](https://user-images.githubusercontent.com/7882693/129279602-68b638be-0a87-4b07-b885-3cf38593b2a5.png)

where the green diamond is the scene's center (`centerLon`, `centerLat`) as defined in the metadata, black circle is using shapely, and red circle is the existing numpy implementation.

This drops numpy as a requirement (only used by centroid) and adds shapely. 

---

An alternative approach, once [`centerLon` and `centerLat` are in the GeoJSON properties](https://github.com/asfadmin/Discovery-SearchAPI/commit/51bacc2055fd7e6f0acf60843af7e33901b17d79), would be to leverage those instead, assuming that's available for all product types. 
* could either drop the centroid function or return `(self.properties['centerLon'], self.properties['centerLat'])`
* can use those properties in `asf_search.baseline_search.get_stack_params` like:
  ```python
  stack_params['intersectsWith'] = f'POINT({reference.properties["centerLon"]} {reference.properties["centerLat"]})'