### PR TITLE
Missing CMR Module hotfix

### DIFF
--- a/asf_search/CMR/__init__.py
+++ b/asf_search/CMR/__init__.py
@@ -1,0 +1,1 @@
+from .MissionList import get_campaigns

--- a/asf_search/__init__.py
+++ b/asf_search/__init__.py
@@ -19,3 +19,4 @@ from .constants import *
 from .health import *
 from .search import *
 from .download import *
+from .CMR import *


### PR DESCRIPTION
adds missing __init__.py for asf_search.CMR module, imports to asf_search module