### PR TITLE
Missing CMR-Module Hotfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,23 +25,18 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 -
 
 -->
-## [3.2.0](https://github.com/asfadmin/Discovery-PytestAutomation/compare/v3.1.0...vv3.2.0)
-### Added:
-- Added `campaigns()` in `Campaigns` module, returns a list of campaigns for `UAV, AIRSAR, SENTINEL-1 INTERFEROGRAM (BETA)` platforms
 
-### Changed:
-- "collectionName" parameter in `geo_search()` and `search()` is deprecated and raises a warning. Will be removed in a future release, use "campaign" instead
-
-------
 ## [3.1.0](https://github.com/asfadmin/Discovery-asf_search/compare/v3.0.6...v3.1.0)
 ### Added
 - Added walkthrough in the form of several jupyter notebooks in /examples
+- Added `campaigns()` in `Campaigns` module, returns a list of campaigns for `UAV, AIRSAR, SENTINEL-1 INTERFEROGRAM (BETA)` platforms
 
 ### Changed
 - Re-enable run-pytest workflow
   - Add tests for `ASFSearch, ASFSession, ASFProduct` as well as baseline, geographic, and search modules
   - Add Pytest-Automation Plugin integration
   - Add automated CodeCov badge to readme
+- "collectionName" parameter in `geo_search()` and `search()` is deprecated and raises a warning. Will be removed in a future release, use "campaign" instead
 
 ### Fixed
 - Fix error while raising ASFBaselineError in `baseline_search.get_stack_params()`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,11 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 -
 
 -->
+## [3.1.1](https://github.com/asfadmin/Discovery-PytestAutomation/compare/v3.1.0...v3.1.1)
+### Fixed:
+- Fixes missing CMR module import
 
+------
 ## [3.1.0](https://github.com/asfadmin/Discovery-asf_search/compare/v3.0.6...v3.1.0)
 ### Added
 - Added walkthrough in the form of several jupyter notebooks in /examples

--- a/asf_search/CMR/__init__.py
+++ b/asf_search/CMR/__init__.py
@@ -1,0 +1,1 @@
+from .MissionList import get_campaigns

--- a/asf_search/__init__.py
+++ b/asf_search/__init__.py
@@ -19,3 +19,4 @@ from .constants import *
 from .health import *
 from .search import *
 from .download import *
+from .CMR import *


### PR DESCRIPTION
## [3.1.1](https://github.com/asfadmin/Discovery-PytestAutomation/compare/v3.1.0...v3.1.1)
### Fixed:
- Fixes missing CMR module import