### PR TITLE
Hotfix: calculate_perpendicular_baselines() now returns ASFSearchResults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,10 +25,16 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 -
 
 -->
+## [3.2.1](https://github.com/asfadmin/Discovery-PytestAutomation/compare/v3.2.0...v3.2.1)
+### Fixed
+- `ASFProduct.stack()` and `asf_search.baseline_search.stack_from_id()` now return ASFSearchResults instead of a list
+
+------
 ## [3.2.0](https://github.com/asfadmin/Discovery-PytestAutomation/compare/v3.1.3...v3.2.0)
 ### Changed
 - `ASFProduct.stack()` and `asf_search.baseline_search.stack_from_id()` now calculate `temporalBaseline` and `perpendicularBaseline` values of stacked products locally
 - `search()` now internally uses a custom format when communicating with ASF's SearchAPI. This should have no apparent impact on current usage of asf_search. 
+
 ------
 ## [3.1.3](https://github.com/asfadmin/Discovery-PytestAutomation/compare/v3.1.2...v3.1.3)
 ### Fixed

--- a/asf_search/baseline/calc.py
+++ b/asf_search/baseline/calc.py
@@ -4,14 +4,14 @@ from typing import List
 import numpy as np
 from dateutil.parser import parse
 
-from asf_search import ASFProduct, ASFSearchResults
+from asf_search import ASFProduct
 # WGS84 constants
 a = 6378137
 f = pow((1.0 - 1 / 298.257224), 2)
 # Technically f is normally considered to just be that 298... part but this is all we ever use, so
 # pre-calc and cache and call it all f anyhow
 
-def calculate_perpendicular_baselines(reference: str, stack: List[ASFProduct]) -> ASFSearchResults:
+def calculate_perpendicular_baselines(reference: str, stack: List[ASFProduct]):
     for product in stack:
         baselineProperties = product.baseline
         positionProperties = baselineProperties['stateVectors']['positions']
@@ -68,7 +68,7 @@ def calculate_perpendicular_baselines(reference: str, stack: List[ASFProduct]) -
             perpendicular_baseline = None
         secondary.properties['perpendicularBaseline'] = perpendicular_baseline
 
-    return ASFSearchResults(stack)
+    return stack
 
 # Convert granule center lat/lon to fixed earth coordinates in meters using WGS84 ellipsoid.
 def get_granule_position(scene_center_lat, scene_center_lon):

--- a/asf_search/baseline/calc.py
+++ b/asf_search/baseline/calc.py
@@ -4,14 +4,14 @@ from typing import List
 import numpy as np
 from dateutil.parser import parse
 
-from asf_search import ASFProduct
+from asf_search import ASFProduct, ASFSearchResults
 # WGS84 constants
 a = 6378137
 f = pow((1.0 - 1 / 298.257224), 2)
 # Technically f is normally considered to just be that 298... part but this is all we ever use, so
 # pre-calc and cache and call it all f anyhow
 
-def calculate_perpendicular_baselines(reference: str, stack: List[ASFProduct]):
+def calculate_perpendicular_baselines(reference: str, stack: List[ASFProduct]) -> ASFSearchResults:
     for product in stack:
         baselineProperties = product.baseline
         positionProperties = baselineProperties['stateVectors']['positions']
@@ -68,7 +68,7 @@ def calculate_perpendicular_baselines(reference: str, stack: List[ASFProduct]):
             perpendicular_baseline = None
         secondary.properties['perpendicularBaseline'] = perpendicular_baseline
 
-    return stack
+    return ASFSearchResults(stack)
 
 # Convert granule center lat/lon to fixed earth coordinates in meters using WGS84 ellipsoid.
 def get_granule_position(scene_center_lat, scene_center_lon):

--- a/asf_search/baseline/stack.py
+++ b/asf_search/baseline/stack.py
@@ -20,7 +20,7 @@ def get_baseline_from_stack(reference: ASFProduct, stack: ASFSearchResults):
     else:
         stack = calculate_perpendicular_baselines(reference.properties['sceneName'], stack)
 
-    return stack, warnings
+    return ASFSearchResults(stack), warnings
 
 def valid_state_vectors(product: ASFProduct):
     if product is None:


### PR DESCRIPTION
## [3.2.1](https://github.com/asfadmin/Discovery-PytestAutomation/compare/v3.2.0...v3.2.1)
### Fixed
- `ASFProduct.stack()` and `asf_search.baseline_search.stack_from_id()` now return ASFSearchResults instead of a list

------