### PR TITLE
Allow empty ASFProduct instantiation

### DIFF
--- a/asf_search/ASFProduct.py
+++ b/asf_search/ASFProduct.py
@@ -8,7 +8,7 @@ from asf_search.CMR import translate_product
 
 
 class ASFProduct:
-    def __init__(self, args: dict, session: ASFSession=ASFSession()):
+    def __init__(self, args: dict = {}, session: ASFSession = ASFSession()):
         self.meta = args.get('meta')
         self.umm = args.get('umm')
 


### PR DESCRIPTION
We're letting literally everything else be empty at this point, so we might as well go this extra step.