### PR TITLE
Fix Polygon Bounding Box bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [5.0.1](https://github.com/asfadmin/Discovery-asf_search/compare/v5.0.0...v5.0.1)
 ### Changed
 - `ASFProduct` is now aware of the session used during search (if available) and will use that by default to download. A session can still be explicitly provided as before.
-- If no opts is provided to `ASFProduct.stack()`, the default will now use the session used to create the product.
+- `ASFProduct.stack()` now uses the session provided via the opts argument. If none is provided, it will use the session referenced by `ASFProduct.session`.
 - `ASFProduct` more gracefully handles missing or malformed metadata during instantiation.
 
 ------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 -->
 
+## [5.0.2](https://github.com/asfadmin/Discovery-asf_search/compare/v5.0.1...v5.0.2)
+### Fixed
+- non-rectangular polygons are now sent to CMR instead of their bounding boxes
+
+------
 ## [5.0.1](https://github.com/asfadmin/Discovery-asf_search/compare/v5.0.0...v5.0.1)
 ### Changed
 - `ASFProduct` is now aware of the session used during search (if available) and will use that by default to download. A session can still be explicitly provided as before.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [5.0.1](https://github.com/asfadmin/Discovery-asf_search/compare/v5.0.0...v5.0.1)
 ### Changed
 - `ASFProduct` is now aware of the session used during search (if available) and will use that by default to download. A session can still be explicitly provided as before.
-- `ASFProduct.stack()` now accepts a `session` argument. The object's own session is used by default.
+- If no opts is provided to `ASFProduct.stack()`, the default will now use the session used to create the product.
 - `ASFProduct` more gracefully handles missing or malformed metadata during instantiation.
 
 ------

--- a/asf_search/CMR/translate.py
+++ b/asf_search/CMR/translate.py
@@ -282,7 +282,13 @@ def should_use_bbox(shape: BaseGeometry):
     we should use the bounding box to search instead
     """
     if isinstance(shape, Polygon):
-        return shape.equals(Polygon(shape.boundary.coords))
+        coords = [
+            [shape.bounds[0], shape.bounds[1]], 
+            [shape.bounds[2], shape.bounds[1]],
+            [shape.bounds[2], shape.bounds[3]],
+            [shape.bounds[0], shape.bounds[3]],
+        ]
+        return shape.equals(Polygon(shell=coords))
     
     return False
 


### PR DESCRIPTION
## [5.0.2](https://github.com/asfadmin/Discovery-asf_search/compare/v5.0.1...v5.0.2)
### Fixed
- non-rectangular polygons are now sent to CMR instead of their bounding boxes
