### PR TITLE
Sorts results again at end of search()

### DIFF
--- a/asf_search/search/search.py
+++ b/asf_search/search/search.py
@@ -140,7 +140,7 @@ def search(
         
         opts.session.headers.pop('CMR-Search-After', None)
 
-    # results.sort(key=lambda p: (p.properties['stopTime'], p.properties['fileID']), reverse=True)
+    results.sort(key=lambda p: (p.properties['stopTime'], p.properties['fileID']), reverse=True)
     return results
 
 def get_page(session: ASFSession, url: str, translated_opts: list) -> Response:


### PR DESCRIPTION
CMR's default results sorting was used while testing export feature. This restores sorting to end of `search()`