### PR TITLE
V5.1.1 Page Size Reduced to 500

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 -->
 
+------
+## [5.1.1](https://github.com/asfadmin/Discovery-asf_search/compare/v5.1.0...v5.1.1)
+### Changed
+- `CMR_PAGE_SIZE` reduced from 2000 to 500
+
+------
 ## [5.1.0](https://github.com/asfadmin/Discovery-asf_search/compare/v5.0.2...v5.1.0)
 ### Added
 - Adds export support to ASFSearchResults for `csv`, `jsonlite`, `jsonlite2`, `kml`, `metalink`

--- a/asf_search/constants/INTERNAL.py
+++ b/asf_search/constants/INTERNAL.py
@@ -5,7 +5,7 @@ CMR_FORMAT_EXT = 'umm_json_v1_4'
 CMR_GRANULE_PATH = f'/search/granules.{CMR_FORMAT_EXT}'
 CMR_COLLECTIONS_PATH = f'/search/collections.{CMR_FORMAT_EXT}'
 CMR_HEALTH_PATH = f'/search/health'
-CMR_PAGE_SIZE = 2000
+CMR_PAGE_SIZE = 500
 EDL_HOST = 'urs.earthdata.nasa.gov'
 EDL_CLIENT_ID = 'BO_n7nTIlMljdvU6kRRB3g'
 


### PR DESCRIPTION
## [5.1.1](https://github.com/asfadmin/Discovery-asf_search/compare/v5.1.0...v5.1.1)
### Changed
- `CMR_PAGE_SIZE` reduced from 2000 to 500