### PR TITLE
6.0.0 Release Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 -->
 
 ------
-## [v5.2.0](https://github.com/asfadmin/Discovery-asf_search/compare/v5.1.2...v5.2.0)
+## [v6.0.0](https://github.com/asfadmin/Discovery-asf_search/compare/v5.1.2...v6.0.0)
 ### Added
 - Search errors are now automatically reported to ASF, users can opt out by changing `asf_search.REPORT_ERRORS` after import
   - Example and information available in "Usage" section of /examples/1-Basic_Overview.ipynb
@@ -35,6 +35,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `ASFProduct` now has a `remotezip()` method, which takes a user's pre-authenticated `ASFSession` and returns a `RemoteZip` object. This can be used to list and download specific files from a product's zip archive, rather than the whole zip file. 
   - Example available in /examples/5-Download.ipynb
   - see https://github.com/gtsystem/python-remotezip for further details on how to use the `RemoteZip` class
+- Adds `3FP` product type constant `THREEFP`
 
 ### Changed
 - `search()` will retry request to CMR 3 times, and return previously gathered results if all retries fail. An error will be logged warning the user and the returned results will be marked as incomplete

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `ASFProduct` now has a `remotezip()` method, which takes a user's pre-authenticated `ASFSession` and returns a `RemoteZip` object. This can be used to list and download specific files from a product's zip archive, rather than the whole zip file. 
   - Example available in /examples/5-Download.ipynb
   - see https://github.com/gtsystem/python-remotezip for further details on how to use the `RemoteZip` class.
-- Adds `3FP` product type constant `THREEFP`.
+- Adds `GRD_FD`, `PROJECTED_ML3X3`, `THREEFP` product type constants.
 
 ### Changed
 - `search()` no longer raises search errors. Instead, `search()` will retry the request 3 times. If all 3 attempts fail:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,11 +34,13 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `ASFSearchResults` now has `raise_if_incomplete()` method, raises `ASFSearchError()` if a search encountered an error and was unable to return all results from CMR
 - `ASFProduct` now has a `remotezip()` method, which takes a user's pre-authenticated `ASFSession` and returns a `RemoteZip` object. This can be used to list and download specific files from a product's zip archive, rather than the whole zip file. 
   - Example available in /examples/5-Download.ipynb
-  - see https://github.com/gtsystem/python-remotezip for further details on how to use the `RemoteZip` class
-- Adds `3FP` product type constant `THREEFP`
+  - see https://github.com/gtsystem/python-remotezip for further details on how to use the `RemoteZip` class.
+- Adds `3FP` product type constant `THREEFP`.
 
 ### Changed
-- `search()` will retry request to CMR 3 times, and return previously gathered results if all retries fail. An error will be logged warning the user and the returned results will be marked as incomplete
+- `search()` no longer raises search errors. Instead, `search()` will retry the request 3 times. If all 3 attempts fail:
+  -  `search()` will return all the results it managed to find instead of raising an error.
+  -  An error will be logged warning the user, and the returned results will be marked as incomplete. Use `raise_if_incomplete()` to raise an error when the returned `ASFSearchResults` are incomplete.
 
 ------
 ## [5.1.2](https://github.com/asfadmin/Discovery-asf_search/compare/v5.1.0...v5.1.2)


### PR DESCRIPTION
PR to prepare master branch changelog for stable release

## [v6.0.0](https://github.com/asfadmin/Discovery-asf_search/compare/v5.1.2...v6.0.0)
### Added
- Search errors are now automatically reported to ASF, users can opt out by changing `asf_search.REPORT_ERRORS` after import
  - Example and information available in "Usage" section of /examples/1-Basic_Overview.ipynb
- `ASFSearchResults` now has `raise_if_incomplete()` method, raises `ASFSearchError()` if a search encountered an error and was unable to return all results from CMR
- `ASFProduct` now has a `remotezip()` method, which takes a user's pre-authenticated `ASFSession` and returns a `RemoteZip` object. This can be used to list and download specific files from a product's zip archive, rather than the whole zip file. 
  - Example available in /examples/5-Download.ipynb
  - see https://github.com/gtsystem/python-remotezip for further details on how to use the `RemoteZip` class.
- Adds `3FP` product type constant `THREEFP`.

### Changed
- `search()` no longer raises search errors. Instead, `search()` will retry the request 3 times. If all 3 attempts fail:
  -  `search()` will return all the results it managed to find instead of raising an error.
  -  An error will be logged warning the user, and the returned results will be marked as incomplete. Use `raise_if_incomplete()` to raise an error when the returned `ASFSearchResults` are incomplete.