### PR TITLE
Codecov Python Workflow Update

### DIFF
--- a/.github/workflows/run-pytest.yml
+++ b/.github/workflows/run-pytest.yml
@@ -17,9 +17,9 @@ jobs:
         run: python3 -m pytest -n auto --cov=asf_search --cov-report=xml --dont-run-file test_known_bugs .
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
         with:
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           files: ./coverage.xml
           flags: unittests
           name: asf_admin pytest


### PR DESCRIPTION
- bumps codecov version from 2 to 3
- set `fail_ci_if_error` flag to false (would cause workflow to fail if error encountered with uploading coverage)