### PR TITLE
Let users choose what type of burst data they download

### DIFF
--- a/asf_search/ASFProduct.py
+++ b/asf_search/ASFProduct.py
@@ -7,6 +7,8 @@ from asf_search.download import download_url
 from asf_search.CMR import translate_product
 from remotezip import RemoteZip
 
+from asf_search.download.file_download_type import FileDownloadType
+
 
 class ASFProduct:
     def __init__(self, args: dict = {}, session: ASFSession = ASFSession()):
@@ -30,7 +32,7 @@ class ASFProduct:
             'properties': self.properties
         }
 
-    def download(self, path: str, filename: str = None, session: ASFSession = None) -> None:
+    def download(self, path: str, filename: str = None, session: ASFSession = None, files = FileDownloadType.DEFAULT_FILE) -> None:
         """
         Downloads this product to the specified path and optional filename.
 
@@ -41,12 +43,34 @@ class ASFProduct:
         :return: None
         """
         if filename is None:
-            filename = self.properties['fileName']
+            default_filename = self.properties['fileName']
         
         if session is None:
             session = self.session
 
-        download_url(url=self.properties['url'], path=path, filename=filename, session=session)
+        urls = []
+
+        def get_additional_urls():
+            output = []
+            base_filename = '.'.join(default_filename.split('.')[:-1])
+            for url in self.properties['additionalUrls']:
+                extension = url.split('.')[-1]
+                urls.append((f"{base_filename}.{extension}", url))
+            
+            return output
+
+        if files == FileDownloadType.DEFAULT_FILE:
+            urls.append((default_filename, self.properties['url']))
+        elif files == FileDownloadType.ADDITIONAL_FILES:
+            urls.extend(get_additional_urls())
+        elif files == FileDownloadType.ALL_FILES:
+            urls.append((default_filename, self.properties['url']))
+            urls.extend(get_additional_urls())
+        else:
+            raise ValueError("Invalid FileDownloadType provided, the valid types are 'DEFAULT_FILE', 'ADDITIONAL_FILES', and 'ALL_FILES'")
+
+        for filename, url in urls:
+            download_url(url=url, path=path, filename=filename, session=session)
 
     def stack(
             self,

--- a/asf_search/ASFSearchResults.py
+++ b/asf_search/ASFSearchResults.py
@@ -2,6 +2,7 @@ from collections import UserList
 from multiprocessing import Pool
 import json
 from asf_search import ASFSession, ASFSearchOptions
+from asf_search.download.file_download_type import FileDownloadType
 from asf_search.exceptions import ASFSearchError
 
 from asf_search import ASF_LOGGER
@@ -47,7 +48,8 @@ class ASFSearchResults(UserList):
             self,
             path: str,
             session: ASFSession = None,
-            processes: int = 1
+            processes: int = 1,
+            files = FileDownloadType.DEFAULT_FILE
     ) -> None:
         """
         Iterates over each ASFProduct and downloads them to the specified path.
@@ -61,7 +63,7 @@ class ASFSearchResults(UserList):
         ASF_LOGGER.info(f"Started downloading ASFSearchResults of size {len(self)}.")
         if processes == 1:
             for product in self:
-                product.download(path=path, session=session)
+                product.download(path=path, session=session, files=files)
         else:
             ASF_LOGGER.info(f"Using {processes} threads - starting up pool.")
             pool = Pool(processes=processes)
@@ -78,5 +80,5 @@ class ASFSearchResults(UserList):
             raise ASFSearchError(msg)
 
 def _download_product(args) -> None:
-    product, path, session = args
-    product.download(path=path, session=session)
+    product, path, session, files = args
+    product.download(path=path, session=session, files=files)

--- a/asf_search/CMR/translate.py
+++ b/asf_search/CMR/translate.py
@@ -224,6 +224,7 @@ def translate_product(item: dict) -> dict:
         if urls is not None:
             properties['url'] = urls[0]
             properties['fileName'] = properties['fileID'] + '.' + urls[0].split('.')[-1]
+            properties['additionalUrls'] = [urls[1]]
 
     return {'geometry': geometry, 'properties': properties, 'type': 'Feature', 'baseline': baseline}
 

--- a/asf_search/download/__init__.py
+++ b/asf_search/download/__init__.py
@@ -1,1 +1,2 @@
 from .download import download_urls, download_url, remotezip
+from .file_download_type import FileDownloadType

--- a/asf_search/download/file_download_type.py
+++ b/asf_search/download/file_download_type.py
@@ -1,0 +1,6 @@
+from enum import Enum
+
+class FileDownloadType(Enum):
+    DEFAULT_FILE = 1
+    ADDITIONAL_FILES = 2
+    ALL_FILES = 3


### PR DESCRIPTION
- adds `FileDownloadType` to use with `ASFProduct` and `ASFSearchResults` download
- adds additionalUrls property to `ASFProduct` properties