### PR TITLE
Bugfix: ASFProduct.Download() filename keyword fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [v6.6.1](https://github.com/asfadmin/Discovery-asf_search/compare/v6.6.0...v6.6.1)
 ### Added
 - Adds automated release notes
+### Fixed
+- `filename` can be used again with `ASFProduct.Download()` method (ignored if multiple files are to be downloaded)
 
 ------
 ## [v6.6.0](https://github.com/asfadmin/Discovery-asf_search/compare/v6.5.0...v6.6.0)

--- a/asf_search/ASFProduct.py
+++ b/asf_search/ASFProduct.py
@@ -49,8 +49,8 @@ class ASFProduct:
 
         if filename is not None:
             multiple_files = (
-                (fileType != FileDownloadType.DEFAULT_FILE and len(self.properties['additionalUrls']) > 1) 
-                
+                (fileType == FileDownloadType.ADDITIONAL_FILES and len(self.properties['additionalUrls']) > 1) 
+                or fileType == FileDownloadType.ALL_FILES
             )
             if multiple_files:
                 warnings.warn(f"Attempting to download multiple files for product, ignoring user provided filename argument \"{filename}\", using default.")

--- a/asf_search/ASFProduct.py
+++ b/asf_search/ASFProduct.py
@@ -8,6 +8,7 @@ from asf_search.CMR import translate_product
 from remotezip import RemoteZip
 
 from asf_search.download.file_download_type import FileDownloadType
+from asf_search import ASF_LOGGER
 
 
 class ASFProduct:
@@ -44,7 +45,17 @@ class ASFProduct:
         """
         if filename is None:
             default_filename = self.properties['fileName']
-        
+        elif filename is not None:
+            multiple_files = (
+                (fileType == FileDownloadType.ADDITIONAL_FILES and len(self.properties['additionalUrls']) > 1) 
+                or fileType == FileDownloadType.ALL_FILES
+            )
+            if multiple_files:
+                ASF_LOGGER.warning(f"Attempting to download multiple files for product, ignoring user provided filename argument \"{filename}\", using default.")
+                default_filename = self.properties['fileName']
+            else:
+                default_filename = filename
+                
         if session is None:
             session = self.session
 

--- a/asf_search/ASFProduct.py
+++ b/asf_search/ASFProduct.py
@@ -1,3 +1,4 @@
+import warnings
 from shapely.geometry import shape, Point, Polygon, mapping
 import json
 
@@ -43,16 +44,16 @@ class ASFProduct:
 
         :return: None
         """
-        if filename is None:
-            default_filename = self.properties['fileName']
-        elif filename is not None:
+
+        default_filename = self.properties['fileName']
+
+        if filename is not None:
             multiple_files = (
-                (fileType == FileDownloadType.ADDITIONAL_FILES and len(self.properties['additionalUrls']) > 1) 
-                or fileType == FileDownloadType.ALL_FILES
+                (fileType != FileDownloadType.DEFAULT_FILE and len(self.properties['additionalUrls']) > 1) 
+                
             )
             if multiple_files:
-                ASF_LOGGER.warning(f"Attempting to download multiple files for product, ignoring user provided filename argument \"{filename}\", using default.")
-                default_filename = self.properties['fileName']
+                warnings.warn(f"Attempting to download multiple files for product, ignoring user provided filename argument \"{filename}\", using default.")
             else:
                 default_filename = filename
                 

--- a/tests/ASFProduct/test_ASFProduct.py
+++ b/tests/ASFProduct/test_ASFProduct.py
@@ -76,7 +76,10 @@ def run_test_ASFProduct_download(reference, filename, filetype, additional_urls)
         resp.iter_content = lambda chunk_size: []
             
         with patch('builtins.open', unittest.mock.mock_open()) as m:    
-            if filename != None and (filetype != FileDownloadType.DEFAULT_FILE and (len(additional_urls) > 1)):
+            if filename != None and (
+                (filetype == FileDownloadType.ADDITIONAL_FILES and len(additional_urls) > 1) 
+                or filetype == FileDownloadType.ALL_FILES
+            ):
                 with pytest.warns(Warning):
                     product.download('./', filename=filename, fileType=filetype)
             else:

--- a/tests/ASFProduct/test_ASFProduct.py
+++ b/tests/ASFProduct/test_ASFProduct.py
@@ -1,7 +1,13 @@
-from asf_search import ASFProduct, ASFSearchResults, ASFSearchOptions
+import logging
+import pytest
+import unittest
+
+from asf_search import ASFProduct, ASFSearchResults, ASFSearchOptions, FileDownloadType
 from unittest.mock import patch
 from shapely.geometry import shape
 from shapely.ops import orient
+
+import requests
 
 def run_test_ASFProduct(product_json):
     if product_json is None:
@@ -59,3 +65,19 @@ def run_test_product_get_stack_options(reference, options):
 
     product_options = dict(product.get_stack_opts())
     assert product_options == dict(expected_options)
+
+def run_test_ASFProduct_download(reference, filename, filetype, additional_urls):
+    product = ASFProduct(reference)
+    product.properties['additionalUrls'] = additional_urls
+    with patch('asf_search.ASFSession.get') as mock_get:
+        resp = requests.Response()
+        resp.status_code = 200
+        mock_get.return_value = resp
+        resp.iter_content = lambda chunk_size: []
+            
+        with patch('builtins.open', unittest.mock.mock_open()) as m:    
+            if filename != None and (filetype != FileDownloadType.DEFAULT_FILE and (len(additional_urls) > 1)):
+                with pytest.warns(Warning):
+                    product.download('./', filename=filename, fileType=filetype)
+            else:
+                product.download('./', filename=filename, fileType=filetype)

--- a/tests/download/test_download.py
+++ b/tests/download/test_download.py
@@ -1,7 +1,4 @@
 import unittest
-
-from requests_mock import Adapter
-import requests_mock
 from asf_search.exceptions import ASFAuthenticationError, ASFDownloadError
 import pytest
 from unittest.mock import patch

--- a/tests/pytest-config.yml
+++ b/tests/pytest-config.yml
@@ -15,6 +15,11 @@ test_types:
     required_in_title: ASFProduct-get-stack-options
     method: test_ASFProduct_get_stack_options
 
+- For running ASFProduct_download_file tests:
+    required_keys: ["product", "filename", "filetype", "additionalUrls"]
+    required_in_title: ASFProduct-download-file
+    method: test_ASFProduct_download
+
 - For running ASFSession tests:
     required_in_title: password-login
     required_keys: ['username', 'password']

--- a/tests/pytest-managers.py
+++ b/tests/pytest-managers.py
@@ -1,8 +1,8 @@
 from typing import Dict, List
-from asf_search import ASFSearchOptions, ASFProduct
+from asf_search import ASFSearchOptions, ASFProduct, FileDownloadType
 from asf_search.exceptions import ASFAuthenticationError
 
-from ASFProduct.test_ASFProduct import run_test_ASFProduct, run_test_product_get_stack_options, run_test_stack
+from ASFProduct.test_ASFProduct import run_test_ASFProduct, run_test_ASFProduct_download, run_test_product_get_stack_options, run_test_stack
 from ASFSearchOptions.test_ASFSearchOptions import run_test_ASFSearchOptions
 from ASFSearchResults.test_ASFSearchResults import run_test_output_format, run_test_ASFSearchResults_intersection
 from ASFSession.test_ASFSession import run_auth_with_cookiejar, run_auth_with_creds, run_auth_with_token, run_test_asf_session_rebuild_auth
@@ -56,7 +56,23 @@ def test_ASFProduct_get_stack_options(**args) -> None:
     options = get_resource(test_info['options'])
 
     run_test_product_get_stack_options(reference, options)
- 
+
+def test_ASFProduct_download(**args) -> None:
+    test_info = args["test_info"]
+    reference = get_resource(test_info['product'])
+    filename = test_info['filename']
+    filetype_raw = test_info['filetype']
+    additional_urls = test_info['additionalUrls']
+
+    if filetype_raw == 1:
+        filetype = FileDownloadType.DEFAULT_FILE
+    elif filetype_raw == 2:
+        filetype = FileDownloadType.ADDITIONAL_FILES
+    else:
+        filetype = FileDownloadType.ALL_FILES
+    
+    run_test_ASFProduct_download(reference, filename, filetype, additional_urls)
+    
 # asf_search.ASFSession Tests
 def test_ASFSession_Error(**args) -> None:
     """
@@ -335,7 +351,7 @@ def test_download_url(**args) -> None:
     url = test_info["url"]
     path = test_info["path"]
     filename = test_info["filename"]
-        
+
     if filename == "error":
         run_test_download_url_auth_error(url, path, filename)
     else:

--- a/tests/yml_tests/test_ASFProduct.yml
+++ b/tests/yml_tests/test_ASFProduct.yml
@@ -63,3 +63,77 @@ tests:
         processingLevel: ['L0'],
         insarStackId: '1736495'
     }
+
+- Test ASFProduct-download-file default_file no additional files:
+    product: Fairbanks_SLC.yml
+    filename: null
+    filetype: 1
+    additionalUrls: []
+
+- Test ASFProduct-download-file additional_files no additional files:
+    product: Fairbanks_SLC.yml
+    filename: null
+    filetype: 2
+    additionalUrls: []
+
+- Test ASFProduct-download-file all_files no additional files:
+    product: Fairbanks_SLC.yml
+    filename: null
+    filetype: 3
+    additionalUrls: []
+
+
+- Test ASFProduct-download-file default_file:
+    product: Fairbanks_SLC.yml
+    filename: null
+    filetype: 1
+    additionalUrls: ['test.xml', 'test.tiff']
+
+- Test ASFProduct-download-file additional_files:
+    product: Fairbanks_SLC.yml
+    filename: null
+    filetype: 2
+    additionalUrls: ['test.xml', 'test.tiff']
+
+- Test ASFProduct-download-file all_files:
+    product: Fairbanks_SLC.yml
+    filename: null
+    filetype: 3
+    additionalUrls: ['test.xml', 'test.tiff']
+
+- Test ASFProduct-download-file default_file custom filename:
+    product: Fairbanks_SLC.yml
+    filename: custom_name.txt
+    filetype: 1
+    additionalUrls: ['test.xml', 'test.tiff']
+
+- Test ASFProduct-download-file additional_files custom filename:
+    product: Fairbanks_SLC.yml
+    filename: custom_name.txt
+    filetype: 1
+    additionalUrls: ['test.xml']
+
+- Test ASFProduct-download-file additional_files custom filename:
+    product: Fairbanks_SLC.yml
+    filename: custom_name.txt
+    filetype: 2
+    additionalUrls: ['test.xml']
+
+- Test ASFProduct-download-file multiple additional_files custom filename:
+    product: Fairbanks_SLC.yml
+    filename: custom_name.txt
+    filetype: 2
+    additionalUrls: ['test.xml', 'test.tiff']
+
+- Test ASFProduct-download-file all_files custom filename:
+    product: Fairbanks_SLC.yml
+    filename: custom_name.txt
+    filetype: 3
+    additionalUrls: ['test.xml', 'test.tiff']
+
+
+- Test ASFProduct-download-file all_files custom filename no additional:
+    product: Fairbanks_SLC.yml
+    filename: custom_name.txt
+    filetype: 3
+    additionalUrls: []


### PR DESCRIPTION
- filename works with ASFProduct.download() again
- warns user if downloading multiple files and `filename` is specified, then ignores `filename`