### PR TITLE
BUGFIX: python V3.8 Unsupported Type Hinting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ------
 ## [v6.6.3](https://github.com/asfadmin/Discovery-asf_search/compare/v6.6.2...v6.6.3)
 ### Fixed
-- Fixes type hinting compatibility break introduced in 6.6.2 in `search_generator.py`
+- Fixes type hinting compatibility break introduced in v6.6.2 in `search_generator.py` for Python versions < v3.9
 
 ------
 ## [v6.6.2](https://github.com/asfadmin/Discovery-asf_search/compare/v6.6.1...v6.6.2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 -->
 ------
+## [v6.6.3](https://github.com/asfadmin/Discovery-asf_search/compare/v6.6.2...v6.6.3)
+### Fixed
+- Fixes type hinting compatibility break introduced in 6.6.2 in `search_generator.py`
+
+------
 ## [v6.6.2](https://github.com/asfadmin/Discovery-asf_search/compare/v6.6.1...v6.6.2)
 ### Added
 - Adds new `CMRIncompleteError` exception, raised by search methods when CMR returns an incomplete page

--- a/asf_search/search/search_generator.py
+++ b/asf_search/search/search_generator.py
@@ -19,7 +19,6 @@ from asf_search.exceptions import ASFSearch4xxError, ASFSearch5xxError, ASFSearc
 from asf_search.constants import INTERNAL
 from asf_search.WKT.validate_wkt import validate_wkt
 from asf_search.search.error_reporting import report_search_error
-from typing import List # for 3.8 compatibility
 
 def search_generator(        
         absoluteOrbit: Union[int, Tuple[int, int], Iterable[Union[int, Tuple[int, int]]]] = None,

--- a/asf_search/search/search_generator.py
+++ b/asf_search/search/search_generator.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Generator, Union, Iterable, Tuple
+from typing import Generator, Union, Iterable, Tuple, List
 from copy import copy
 from requests.exceptions import HTTPError
 from requests import ReadTimeout, Response
@@ -19,7 +19,7 @@ from asf_search.exceptions import ASFSearch4xxError, ASFSearch5xxError, ASFSearc
 from asf_search.constants import INTERNAL
 from asf_search.WKT.validate_wkt import validate_wkt
 from asf_search.search.error_reporting import report_search_error
-
+from typing import List # for 3.8 compatibility
 
 def search_generator(        
         absoluteOrbit: Union[int, Tuple[int, int], Iterable[Union[int, Tuple[int, int]]]] = None,
@@ -131,7 +131,7 @@ def query_cmr(session: ASFSession, url: str, translated_opts: dict, sub_query_co
     return items, hits, response.headers.get('CMR-Search-After', None)
     
 
-def process_page(items: list[ASFProduct], max_results: int, subquery_max_results: int, total: int, subquery_count: int, opts: ASFSearchOptions):
+def process_page(items: List[ASFProduct], max_results: int, subquery_max_results: int, total: int, subquery_count: int, opts: ASFSearchOptions):
     if max_results is None:
         last_page = ASFSearchResults(items[:min(subquery_max_results - subquery_count, len(items))], opts=opts)
     else:


### PR DESCRIPTION
- fixes breaking change added to search_generator caused by list type hinting
   - `list[ASFproduct]` only supported in python versions >= 3.9