### PR TITLE
fix asf logger method name error

### DIFF
--- a/asf_search/ASFSearchOptions/ASFSearchOptions.py
+++ b/asf_search/ASFSearchOptions/ASFSearchOptions.py
@@ -114,7 +114,7 @@ class ASFSearchOptions:
             # Spit out warning if the value is something other than the default:
             if not self._is_val_default(key):
                 msg = f'While merging search options, existing option {key}:{getattr(self, key, None)} overwritten by kwarg with value {kwargs[key]}'
-                ASF_LOGGER.warging(msg)
+                ASF_LOGGER.warning(msg)
                 warnings.warn(msg)
             self.__setattr__(key, kwargs[key])
 


### PR DESCRIPTION
I ran into this error and it looks like there is an open issue for it already here https://github.com/asfadmin/Discovery-asf_search/issues/226
This fixes the problem, I was able to jump to the logger warning method definition once the change was applied.