### PR TITLE
S1 Baseline Stacking Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 -->
 ------
+## [v6.7.1](https://github.com/asfadmin/Discovery-asf_search/compare/v6.7.0...v6.7.1)
+### Fixed
+- Fixes issue with certain S1 products not stacking properly in certain environments, which caused null `perpendicularBaseline` values
+
 ## [v6.7.0](https://github.com/asfadmin/Discovery-asf_search/compare/v6.6.3...v6.7.0)
 ### Added
 - Adds new `dataset` keyword to `search()` as an alternative to `platform`. Allows users to get results from multiple platforms at once in a single page

--- a/asf_search/CMR/translate.py
+++ b/asf_search/CMR/translate.py
@@ -195,7 +195,15 @@ def translate_product(item: dict) -> dict:
     velocities['postVelocity'], velocities['postVelocityTime'] = cast(get_state_vector, get(umm, 'AdditionalAttributes', ('Name', 'SV_VELOCITY_POST'), 'Values', 0))
     ascendingNodeTime = get(umm, 'AdditionalAttributes', ('Name', 'ASC_NODE_TIME'), 'Values', 0)
 
-
+    for key in ['prePositionTime','postPositionTime','preVelocityTime','postVelocityTime']:
+        if positions.get(key) is not None:
+            if not positions.get(key).endswith('Z'):
+                positions[key] += 'Z'
+    
+    if ascendingNodeTime is not None:
+        if not ascendingNodeTime.endswith('Z'):
+            ascendingNodeTime += 'Z'
+    
     stateVectors = {
         'positions': positions,
         'velocities': velocities


### PR DESCRIPTION
Inconsistency between `datetime.timestamp()` across systems causes `timestamp()` to infer different timezones for date objects. Baseline calculations depends on these values, and when certain product baseline values lacked the timezone indicator it'd lead to bad baseline values depending on the system environment.

Solution:
- appends 'Z' to S1 baseline date properties if missing (ascending node time, sv times, etc)