### PR TITLE
Adds subproduct class type casting to baseline_search

### DIFF
--- a/asf_search/ASFProduct.py
+++ b/asf_search/ASFProduct.py
@@ -1,6 +1,6 @@
 from enum import Enum
 import os
-from typing import Callable, Tuple, Type, Union, List, final
+from typing import Tuple, Type, Union, List, final
 import warnings
 from shapely.geometry import shape, Point, Polygon, mapping
 import json

--- a/asf_search/ASFProduct.py
+++ b/asf_search/ASFProduct.py
@@ -166,13 +166,13 @@ class ASFProduct:
     def stack(
             self,
             opts: ASFSearchOptions = None,
-            ASFProductSubclass: Union[Type['ASFProduct'], Callable[['ASFProduct'], 'ASFProduct']] = None
+            ASFProductSubclass: Type['ASFProduct'] = None
     ) -> ASFSearchResults:
         """
         Builds a baseline stack from this product.
 
         :param opts: An ASFSearchOptions object describing the search parameters to be used. Search parameters specified outside this object will override in event of a conflict.
-        :param ASFProductSubclass: An ASFProduct subclass constructor, or a callable that takes an ASFProduct object and returns and object of type ASFProduct. 
+        :param ASFProductSubclass: An ASFProduct subclass constructor.
     
         :return: ASFSearchResults containing the stack, with the addition of baseline values (temporal, perpendicular) attached to each ASFProduct.
         """
@@ -398,60 +398,3 @@ class ASFProduct:
             return f(v)
         except TypeError:
             return None
-
-    @final
-    def cast_to_subclass(self, subclass: Union[Type['ASFProduct'], Callable[['ASFProduct'], 'ASFProduct']]) -> 'ASFProduct':
-        """
-        Casts this ASFProduct object as a new object of return type subclass.
-
-        example:
-        ```
-        class MyCustomClass(ASFProduct):
-            _base_properties = {
-            'some_unique_property': {'path': ['AdditionalAttributes', 'UNIQUE_PROPERTY', ...]}
-            }
-            
-            ...
-            
-            @staticmethod
-            def get_property_paths() -> dict:
-            return {
-                **ASFProduct.get_property_paths(),
-                **MyCustomClass._base_properties
-            }
-        
-        # subclass as constructor
-        customReference = reference.cast_to_subclass(MyCustomClass)
-        print(customReference.properties['some_unique_property'])
-
-        # sublclass as callable
-        def convert_to_product_if(original_product: ASFProduct) -> ASFProduct:
-            # conversion logic here
-            if original_product.properties['processingLevel'] == ''
-                return MyCustomClass(
-                    args={'umm': original_product.umm, 'meta': original_product.meta}, 
-                    session=original_product.session
-                    )
-            
-            # otherwise return orignal product
-            return original_product
-
-        customReference = reference.cast_to_subclass(convert_to_product_if)
-        ```
-
-        :param subclass: The ASFProduct subclass to convert to or a method with signature `func(original: ASFProduct) -> ASFProduct`
-        :returns `ASFProduct` of return type `subclass`
-        """
-
-        try:
-            if isinstance(subclass, Type[ASFProduct]):
-                return subclass(args={'umm': self.umm, 'meta': self.meta}, session=self.session)
-            elif isinstance(subclass, Callable[[ASFProduct], ASFProduct]):
-                output = subclass(self)
-                if not isinstance(output, ASFProduct):
-                    raise ValueError(f"Expected returned object of type `ASFProduct` from callable {subclass}, got {type(output)}")
-                return output
-            
-            raise ValueError(f"Expected subclass or method of return type ASFProduct, got {type(subclass)}")
-        except Exception as e:
-            raise ValueError(f"Unable to use provided subclass {type(subclass)}")

--- a/asf_search/ASFProduct.py
+++ b/asf_search/ASFProduct.py
@@ -166,7 +166,7 @@ class ASFProduct:
     def stack(
             self,
             opts: ASFSearchOptions = None,
-            ASFProductSubclass: Type['ASFProduct'] = None
+            useSubclass: Type['ASFProduct'] = None
     ) -> ASFSearchResults:
         """
         Builds a baseline stack from this product.
@@ -181,7 +181,7 @@ class ASFProduct:
         if opts is None:
             opts = ASFSearchOptions(session=self.session)
 
-        return stack_from_product(self, opts=opts, ASFProductSubclass=ASFProductSubclass)
+        return stack_from_product(self, opts=opts, ASFProductSubclass=useSubclass)
 
     def get_stack_opts(self, opts: ASFSearchOptions = None) -> ASFSearchOptions:
         """

--- a/asf_search/ASFSearchResults.py
+++ b/asf_search/ASFSearchResults.py
@@ -98,17 +98,6 @@ class ASFSearchResults(UserList):
         
         return subclasses
     
-    def cast_to_subclass(self, ASFProductSubclass: Union[Type['ASFProduct'], Callable[['ASFProduct'], 'ASFProduct']]) -> None:
-        """Converts products to provided return type in-place, taking either a constructor or callable"""
-        converted = 0
-        for idx, product in enumerate(self.data):
-            converted_product = product.cast_to_subclass(ASFProductSubclass)
-            if converted_product != product:
-                self.data[idx] = converted_product
-                converted+=1
-        
-        ASF_LOGGER.debug(f"Converted {converted} products to custom ASFProduct subclass type")
-
 def _download_product(args) -> None:
     product, path, session, fileType = args
     product.download(path=path, session=session, fileType=fileType)

--- a/asf_search/ASFSearchResults.py
+++ b/asf_search/ASFSearchResults.py
@@ -3,7 +3,7 @@ from multiprocessing import Pool
 from functools import reduce
 import json
 from typing import Type, Callable, Union
-from asf_search import ASFSession, ASFSearchOptions, ASFProduct
+from asf_search import ASFSession, ASFSearchOptions
 from asf_search.download.file_download_type import FileDownloadType
 from asf_search.exceptions import ASFSearchError
 
@@ -98,7 +98,7 @@ class ASFSearchResults(UserList):
         
         return subclasses
     
-    def cast_to_subclass(self, ASFProductSubclass: Union[Type[ASFProduct], Callable[[ASFProduct], ASFProduct]]) -> None:
+    def cast_to_subclass(self, ASFProductSubclass: Union[Type['ASFProduct'], Callable[['ASFProduct'], 'ASFProduct']]) -> None:
         """Converts products to provided return type in-place, taking either a constructor or callable"""
         converted = 0
         for idx, product in enumerate(self.data):

--- a/asf_search/Products/ARIAS1GUNWProduct.py
+++ b/asf_search/Products/ARIAS1GUNWProduct.py
@@ -41,6 +41,10 @@ class ARIAS1GUNWProduct(S1Product):
         """
         return None
     
+
+    def is_valid_reference(self):
+        return False
+    
     @staticmethod
     def get_default_baseline_product_type() -> None:
         """

--- a/asf_search/Products/ARIAS1GUNWProduct.py
+++ b/asf_search/Products/ARIAS1GUNWProduct.py
@@ -1,5 +1,6 @@
 from typing import Dict
 from asf_search import ASFSession
+from asf_search.ASFSearchOptions import ASFSearchOptions
 from asf_search.Products import S1Product
 from asf_search.CMR.translate import try_parse_float
 
@@ -31,3 +32,18 @@ class ARIAS1GUNWProduct(S1Product):
             **S1Product.get_property_paths(),
             **ARIAS1GUNWProduct._base_properties
         }
+
+    def get_stack_opts(self, opts: ASFSearchOptions = None) -> ASFSearchOptions:
+        """
+        Build search options that can be used to find an insar stack for this product
+
+        :return: ASFSearchOptions describing appropriate options for building a stack from this product
+        """
+        return None
+    
+    @staticmethod
+    def get_default_baseline_product_type() -> None:
+        """
+        Returns the product type to search for when building a baseline stack.
+        """
+        return None

--- a/asf_search/Products/OPERAS1Product.py
+++ b/asf_search/Products/OPERAS1Product.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import Dict, Optional
 from asf_search import ASFSearchOptions, ASFSession
 from asf_search.Products import S1Product
 
@@ -64,9 +64,25 @@ class OPERAS1Product(S1Product):
             **S1Product.get_property_paths(),
             **OPERAS1Product._base_properties
         }
+    
+    @staticmethod
+    def get_default_baseline_product_type() -> None:
+        """
+        Returns the product type to search for when building a baseline stack.
+        """
+        return None
+
 
     def is_valid_reference(self):
         return False
+
+    def get_stack_opts(self, opts: ASFSearchOptions = None) -> ASFSearchOptions:
+        """
+        Build search options that can be used to find an insar stack for this product
+
+        :return: ASFSearchOptions describing appropriate options for building a stack from this product
+        """
+        return None
 
     def get_sort_keys(self):
         keys = super().get_sort_keys()

--- a/asf_search/Products/OPERAS1Product.py
+++ b/asf_search/Products/OPERAS1Product.py
@@ -72,7 +72,6 @@ class OPERAS1Product(S1Product):
         """
         return None
 
-
     def is_valid_reference(self):
         return False
 

--- a/asf_search/Products/S1Product.py
+++ b/asf_search/Products/S1Product.py
@@ -1,6 +1,6 @@
 import copy
 from typing import Dict, List, Optional, Tuple
-from asf_search import ASFSearchOptions, ASFSession, ASFProduct, ASFStackableProduct
+from asf_search import ASFSearchOptions, ASFSession, ASFStackableProduct
 from asf_search.CMR.translate import try_parse_int
 from asf_search.constants import PLATFORM
 from asf_search.constants import PRODUCT_TYPE
@@ -25,7 +25,7 @@ class S1Product(ASFStackableProduct):
     - frameNumber: overrides ASFProduct's `CENTER_ESA_FRAME` with `FRAME_NUMBER`
     """
 
-    baseline_type = ASFStackableProduct.BaselineCalcType
+    baseline_type = ASFStackableProduct.BaselineCalcType.CALCULATED
 
     def __init__(self, args: Dict = {}, session: ASFSession = ASFSession()):
         super().__init__(args, session)
@@ -133,6 +133,9 @@ class S1Product(ASFStackableProduct):
 
         return True
 
+    def is_valid_reference(self):
+        return False
+    
     @staticmethod
     def get_default_baseline_product_type() -> str:
         """

--- a/asf_search/Products/S1Product.py
+++ b/asf_search/Products/S1Product.py
@@ -132,9 +132,6 @@ class S1Product(ASFStackableProduct):
                 return False
 
         return True
-
-    def is_valid_reference(self):
-        return False
     
     @staticmethod
     def get_default_baseline_product_type() -> str:

--- a/asf_search/baseline/stack.py
+++ b/asf_search/baseline/stack.py
@@ -10,6 +10,7 @@ def get_baseline_from_stack(reference: ASFProduct, stack: ASFSearchResults):
     if len(stack) == 0:
         raise ValueError('No products found matching stack parameters')
     stack = [product for product in stack if not product.properties['processingLevel'].lower().startswith('metadata') and product.baseline != None]
+    
     reference, stack, warnings = check_reference(reference, stack)
     
     stack = calculate_temporal_baselines(reference, stack)

--- a/asf_search/search/baseline_search.py
+++ b/asf_search/search/baseline_search.py
@@ -1,5 +1,4 @@
 from typing import Callable, Type, Union
-from asf_search.ASFSearchOptions.validators import parse_subclass
 from asf_search.baseline.stack import get_baseline_from_stack
 from copy import copy
 

--- a/asf_search/search/baseline_search.py
+++ b/asf_search/search/baseline_search.py
@@ -43,7 +43,7 @@ def stack_from_product(
     is_complete = stack.searchComplete
 
     if ASFProductSubclass is not None:
-        _try_cast_results_to_subclass(stack, ASFProductSubclass)
+        _cast_results_to_subclass(stack, ASFProductSubclass)
 
     stack, warnings = get_baseline_from_stack(reference=reference, stack=stack)
     stack.searchComplete = is_complete # preserve final outcome of earlier search()
@@ -80,18 +80,18 @@ def stack_from_id(
     reference = reference_results[0]
     
     if useSubclass is not None:
-        reference = _try_cast_to_subclass(reference, useSubclass)
+        reference = _cast_to_subclass(reference, useSubclass)
         
     return reference.stack(opts=opts, useSubclass=useSubclass)
 
-def _try_cast_results_to_subclass(stack: ASFProduct, ASFProductSubclass: Type[ASFProduct]):
+def _cast_results_to_subclass(stack: ASFSearchResults, ASFProductSubclass: Type[ASFProduct]):
     """
     Converts results from default ASFProduct subclasses to custom ones
     """
     for idx, product in enumerate(stack):
-        stack[idx] = _try_cast_to_subclass(product, ASFProductSubclass)
+        stack[idx] = _cast_to_subclass(product, ASFProductSubclass)
 
-def _try_cast_to_subclass(product: ASFProduct, subclass: Type[ASFProduct]) -> ASFProduct:
+def _cast_to_subclass(product: ASFProduct, subclass: Type[ASFProduct]) -> ASFProduct:
     """
     Casts this ASFProduct object as a new object of return type subclass.
 

--- a/asf_search/search/baseline_search.py
+++ b/asf_search/search/baseline_search.py
@@ -56,7 +56,7 @@ def stack_from_product(
 def stack_from_id(
         reference_id: str,
         opts: ASFSearchOptions = None,
-        ASFProductSubclass: Type[ASFProduct] = None
+        useSubclass: Type[ASFProduct] = None
 ) -> ASFSearchResults:
     """
     Finds a baseline stack from a reference product ID
@@ -79,11 +79,10 @@ def stack_from_id(
         raise ASFSearchError(f'Reference product not found: {reference_id}')
     reference = reference_results[0]
     
-    if ASFProductSubclass is not None:
-        reference = _try_cast_to_subclass(reference, ASFProductSubclass)
+    if useSubclass is not None:
+        reference = _try_cast_to_subclass(reference, useSubclass)
         
-
-    return stack_from_product(reference, opts=opts, ASFProductSubclass=ASFProductSubclass)
+    return reference.stack(opts=opts, useSubclass=useSubclass)
 
 def _try_cast_results_to_subclass(stack: ASFProduct, ASFProductSubclass: Type[ASFProduct]):
     """

--- a/examples/Advanced-Custom-ASFProduct-Subclassing.ipynb
+++ b/examples/Advanced-Custom-ASFProduct-Subclassing.ipynb
@@ -4,9 +4,27 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Subclassing `ASFProduct`\n",
+    "# `ASFProduct` Subclasses\n",
     "\n",
-    "`ASFProduct` is the base class for all search result objects as of asf-search v7.0.0. There are several subclasses of `ASFProduct` that asf-search uses for specific platforms and product types with unique properties/functionality."
+    "`ASFProduct` is the base class for all search result objects as of asf-search v7.0.0. There are several subclasses of `ASFProduct` that asf-search uses for specific platforms and product types with unique properties/functionality.\n",
+    "\n",
+    "Key Methods:\n",
+    "- `geojson()`\n",
+    "- `download()`\n",
+    "- `stack()`\n",
+    "- `get_stack_opts()` (returns None in `ASFProduct`, implemented by `ASFStackableProduct` subclass and its subclasses)\n",
+    "- `centroid()`\n",
+    "- `remotezip()` (requires asf-search's optional dependency be installed)\n",
+    "- `get_property_paths()` (gets product's keywords and their paths in umm dictionary)\n",
+    "- `translate_product()` (reads properties from umm, populates `properties` with associated keyword)\n",
+    "- `get_sort_keys()`\n",
+    "- `umm_get()`\n",
+    "\n",
+    "Key Properties:\n",
+    "- `properties`\n",
+    "- `_base_properties` (What `get_property_paths()` uses to find values in umm json `properties`)\n",
+    "- `umm` (The product's umm JSON from CMR)\n",
+    "- `metadata` (The product's metadata JSON from CMR)"
    ]
   },
   {
@@ -16,7 +34,7 @@
    "outputs": [],
    "source": [
     "import asf_search as asf\n",
-    "products = ['S1A_IW_SLC__1SDV_20231224T032123_20231224T032150_051791_064179_16F5-SLC', 'S1_185682_IW2_20210224T161634_VV_035E-BURST','S1-GUNW-D-R-087-tops-20190301_20190223-161540-20645N_18637N-PP-7a85-v2_0_1-unwrappedPhase','ALPSRP111041130-RTC_HI_RES']\n",
+    "products = ['S1A_IW_SLC__1SDV_20231226T162948_20231226T163016_051828_0642C6_272F-SLC', 'S1_185682_IW2_20210224T161634_VV_035E-BURST','S1-GUNW-D-R-087-tops-20190301_20190223-161540-20645N_18637N-PP-7a85-v2_0_1-unwrappedPhase','ALPSRP111041130-RTC_HI_RES', 'UA_newyor_03204_22005-013_22010-002_0014d_s01_L090_01-INTERFEROMETRY']\n",
     "results = asf.product_search(product_list=products)\n",
     "results"
    ]
@@ -25,8 +43,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Notice the different type in the `results` list: `S1Product`, `S1BURSTProduct`, `ARIAS1GUNWProduct`, and `ALOSProduct`.\n",
-    "Each of these are subclasses of type `ASFProduct`.\n",
+    "Notice the different type in the `results` list: `S1Product`, `S1BURSTProduct`, `ARIAS1GUNWProduct`, `ALOSProduct`, and `UAVSARProduct`.\n",
+    "Each of these classes are subclassed from `ASFProduct` in some way.\n",
     "\n",
     "Let's compare the `properties` of `S1Product` and `ALOSProduct`"
    ]
@@ -37,7 +55,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "s1, s1Burst, ariaGunw, alos = results\n",
+    "s1, uavsar, s1Burst, ariaGunw, alos = results\n",
     "\n",
     "def compare_properties(lhs: asf.ASFProduct, rhs: asf.ASFProduct):\n",
     "    # Compares properties of two ASFProduct objects in a color coded table\n",
@@ -55,14 +73,16 @@
     "    for key in keys:\n",
     "        print(f\"{key}:\\n\\t{GREEN}{lhs.properties.get(key, f'{RED}None')}{RESET}\\t{BLUE}{rhs.properties.get(key, f'{RED}None')}{RESET}\\n\")\n",
     "\n",
-    "compare_properties(s1, alos)"
+    "compare_properties(s1, uavsar)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Notice a few properties (marked in red) are missing from each product properties dict. For example, `S1Product` has `pgeVersion`, while `ALOSProduct` has `offNadirAngle`, `faradayRotation`, and `insarStackId`. Moreover, their `baseline` field differs."
+    "Notice a few properties (marked in red) are missing from each product properties dict. For example, `S1Product` has `pgeVersion`, while `UAVSARProduct` has `insarStackId`. \n",
+    "\n",
+    "Moreover, `S1Product` has one major difference with `UAVSARProduct`: `S1Product` inherits from `ASFStackableProduct` (see section below)."
    ]
   },
   {
@@ -72,21 +92,44 @@
    "outputs": [],
    "source": [
     "print(f\"{s1.properties['fileID']}\\n\\t{s1.baseline}\\n\")\n",
-    "print(f\"{alos.properties['fileID']}\\n\\t{alos.baseline}\")"
+    "print(f\"{uavsar.properties['fileID']}\\n\\t{uavsar.baseline}\")"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`ASFProduct` has a class enum, `BaselineCalcType` that determines how asf-search will handle perpendicular stack calculations. Each subclass keeps track of their baseline calculation type via `ASFProduct.baseline_type`\n",
+    "# `ASFStackableProduct`\n",
     "\n",
-    "The three `BaselineCalcType` types:\n",
-    "- `NONE` Cannot be used in baseline calculations\n",
-    "- `PRE_CALCULATED` Has pre-calculated insarBaseline value that will be used for perpendicular calculations\n",
+    "`ASFStackableProduct` is an important `ASFProduct` subclass, from which stackable products types meant for time-series analysis are derived from. `ASFStackableProduct` has a class enum, `BaselineCalcType` that determines how asf-search will handle perpendicular stack calculations. Each subclass keeps track of their baseline calculation type via the `baseline_type` property.\n",
+    "\n",
+    "Inherits: `ASFProduct`\n",
+    "\n",
+    "Inherited By:\n",
+    "- `ALOSProduct`\n",
+    "- `ERSProduct`\n",
+    "- `JERSProduct`\n",
+    "- `RadarsatProduct`\n",
+    "- `S1Product`\n",
+    "    - `S1BurstProduct`\n",
+    "    - `OPERAS1Product` (Stacking currently disabled)\n",
+    "    - `ARIAS1GUNWProduct` (Stacking currently disabled)\n",
+    "\n",
+    "Key Methods:\n",
+    "- `get_baseline_calc_properties()`\n",
+    "- `get_stack_opts()` (Overrides `ASFproduct`)\n",
+    "- `is_valid_reference()`\n",
+    "- `get_default_baseline_product_type()`\n",
+    "\n",
+    "Key Definitions:\n",
+    "class enum `BaselineCalcType`:\n",
+    "- `PRE_CALCULATED` Has pre-calculated `insarBaseline` value that will be used for perpendicular calculations\n",
     "- `CALCULATED` Uses position/velocity state vectors and ascending node time for perpendicular calculations\n",
     "\n",
-    "Any subclass object that changes `baseline_type` from the default of `BaselineCalcType.NONE` is elligble for building a baseline stacking with `ASFProduct.stack()` (see the 4-Baseline_Search.ipynb example notebook for more examples of baseline stacking)."
+    "Key Fields:\n",
+    "- `baseline`\n",
+    "- `baseline_type` (`BaselineCalcType.PRE_CALCULATED` by default or `BaselineCalcType.CALCULATED`)\n",
+    "\n"
    ]
   },
   {
@@ -96,7 +139,7 @@
    "outputs": [],
    "source": [
     "print(f\"Baseline Calculation Types\")\n",
-    "print(f\"ASFProduct:\\t {asf.ASFProduct.baseline_type}\")\n",
+    "print(f\"ASFProduct:\\t {asf.ASFStackableProduct.baseline_type}\")\n",
     "print(f\"ALOSProduct:\\t {alos.baseline_type}\")\n",
     "print(f\"S1Product:\\t {s1.baseline_type}\")"
    ]
@@ -105,7 +148,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`ASFProduct` subclasses even have their own stack search option methods. The `ASFProduct` implementation of `get_stack_opts()` returns `None`, but subclasses like `S1Product` and `ALOSProduct` have different approaches."
+    "`ASFStackableProduct` subclasses even have their own stack search option methods. The `ASFStackableProduct` implementation of `get_stack_opts()` returns the commonly used params for pre-calculated datasets (processing level and insar stack ID), but subclasses like `S1Product` and `S1BurstProduct` use their own approach. "
    ]
   },
   {
@@ -115,6 +158,7 @@
    "outputs": [],
    "source": [
     "print(f\"S1Product:\\n{s1.get_stack_opts()}\\n\")\n",
+    "print(f\"S1BURSTProduct:\\n{s1Burst.get_stack_opts()}\\n\")\n",
     "print(f\"ALOSProduct:\\n{alos.get_stack_opts()}\")"
    ]
   },
@@ -122,29 +166,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Sublcasses of type `ASFProduct` can just as easily be parent classes to other subclasses, like `S1Product`, which is the parent class to `S1BurstProduct` and `ARIAS1GUNWProduct`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print(\"S1BurstProduct:\")\n",
-    "print(f\"\\tburst dict:\\n\\t{s1Burst.properties['burst']}\")\n",
-    "print(f\"\\nS1BurstProduct.get_stack_opts(): {s1Burst.get_stack_opts()}\\n\\n\")\n",
+    "# Writing Custom `ASFProduct` Subclasses\n",
+    "Because `ASFProduct` is built for subclassing, that means users can provide their own custom subclasses dervied directly from `ASFProduct` or even from a pre-existing subclass like `S1Product` or `OperaS1Product`.\n",
     "\n",
-    "print(f\"ARIAS1GUNWProduct:\")\n",
-    "print(f\"\\tperpendicularBaseline: {ariaGunw.properties['perpendicularBaseline']}\")\n",
-    "print(f\"\\tOrbit: {ariaGunw.properties['orbit']}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Because `ASFProduct` is built for subclassing, that means users can provide their own custom subclasses."
+    "In this example we subclass `S1Product`, and overrides the default `ASFProduct.stack()` with one that returns a _list_ of `S1BurstProduct` stacks based on an area of interest, modify `geojson()` to return state vectors, and add a new helper method for getting raw umm CMR response!"
    ]
   },
   {
@@ -229,17 +254,22 @@
     "                useSubclass: Type[asf.ASFProduct] = None,\n",
     "                aoi: str = None\n",
     "            ) -> Union[ASFSearchResults, List[ASFSearchResults]]:\n",
-    "        \n",
+    "\n",
     "        bursts = asf.search(\n",
     "            groupID=self.properties['groupID'], \n",
     "            processingLevel=asf.PRODUCT_TYPE.BURST,\n",
     "            intersectsWith=aoi if aoi is not None else opts.intersectsWith\n",
     "        )\n",
-    "\n",
-    "        if len(bursts) == 0: # build a regular stack of SLCs if there's no SLC-BURST\n",
-    "            return super().stack(opts=opts, useSubclass=useSubclass)\n",
     "        \n",
-    "        return [burst.stack(opts=opts) for burst in bursts]\n",
+    "        return [burst.stack(opts=opts) for burst in bursts]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "\n",
     "customS1SubclassProduct = MyCustomS1Subclass({'umm': s1.umm, 'meta': s1.meta}, session=s1.session)\n",
     "\n",
@@ -269,8 +299,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fairbanks_area = 'LINESTRING(-147.2885 64.7464,-147.733 64.8586,-148.1878 64.731)'\n",
-    "customStack = customS1SubclassProduct.stack(aoi=fairbanks_area)\n",
+    "palmer_to_anchorage = 'LINESTRING(-149.1052 61.6054,-149.5376 61.3162,-149.8764 61.2122)'\n",
+    "customStack = customS1SubclassProduct.stack(aoi=palmer_to_anchorage)\n",
     "customStack"
    ]
   },
@@ -293,7 +323,7 @@
     "def view_stack_of_stacks(stack_of_stacks: List):\n",
     "    print(f'Found {len(stack_of_stacks)} SLC-BURST stacks over AOI, stack lengths:')\n",
     "    for stack_idx, stack in enumerate(stack_of_stacks):\n",
-    "        print(f\"\\t{stack_idx+1}:\\t{len(stack)} SLC-BURSTs \\t(Full Burst ID: {stack[-1].properties['burst']['fullBurstID']})\")\n",
+    "        print(f\"\\t{stack_idx+1}:\\t{len(stack)} SLC-BURSTs \\t(Full Burst ID: {stack[-1].properties['burst']['fullBurstID']}, polarization: {stack[-1].properties['polarization']})\")\n",
     "\n",
     "view_stack_of_stacks(customStack)"
    ]
@@ -313,9 +343,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "opts = asf.ASFSearchOptions(intersectsWith=fairbanks_area) # our custom class will be able to use our aoi this way\n",
+    "opts = asf.ASFSearchOptions(intersectsWith=palmer_to_anchorage) # our custom class will be able to use our aoi this way\n",
     "\n",
-    "customSubclassStack = asf.stack_from_id('S1A_IW_SLC__1SDV_20231224T032123_20231224T032150_051791_064179_16F5-SLC', opts=opts, useSubclass=MyCustomS1Subclass)\n",
+    "customSubclassStack = asf.stack_from_id('S1A_IW_SLC__1SDV_20231226T162948_20231226T163016_051828_0642C6_272F-SLC', opts=opts, useSubclass=MyCustomS1Subclass)\n",
     "\n",
     "view_stack_of_stacks(customSubclassStack)"
    ]

--- a/examples/Advanced-Custom-ASFProduct-Subclassing.ipynb
+++ b/examples/Advanced-Custom-ASFProduct-Subclassing.ipynb
@@ -16,7 +16,7 @@
    "outputs": [],
    "source": [
     "import asf_search as asf\n",
-    "products = ['S1A_IW_SLC__1SDV_20231226T162948_20231226T163016_051828_0642C6_272F-SLC', 'S1_185682_IW2_20210224T161634_VV_035E-BURST','S1-GUNW-D-R-087-tops-20190301_20190223-161540-20645N_18637N-PP-7a85-v2_0_1-unwrappedPhase','ALPSRP111041130-RTC_HI_RES']\n",
+    "products = ['S1A_IW_SLC__1SDV_20231224T032123_20231224T032150_051791_064179_16F5-SLC', 'S1_185682_IW2_20210224T161634_VV_035E-BURST','S1-GUNW-D-R-087-tops-20190301_20190223-161540-20645N_18637N-PP-7a85-v2_0_1-unwrappedPhase','ALPSRP111041130-RTC_HI_RES']\n",
     "results = asf.product_search(product_list=products)\n",
     "results"
    ]
@@ -154,56 +154,90 @@
    "outputs": [],
    "source": [
     "import copy\n",
-    "from typing import Union\n",
+    "from typing import Type, Union\n",
     "from asf_search import ASFSearchOptions, ASFSession\n",
     "from asf_search.ASFSearchOptions import ASFSearchOptions\n",
+    "from asf_search.CMR.translate import try_parse_int\n",
+    "from datetime import datetime\n",
     "\n",
     "class MyCustomS1Subclass(asf.S1Product):\n",
     "    def __init__(\n",
-    "                #default ASFProduct arguments\n",
-    "                self, args: dict = {}, session: ASFSession = ASFSession(), \n",
-    "                #custom properties\n",
-    "                custom_properties: dict = {}\n",
+    "                #default ASFProduct constructor arguments\n",
+    "                self, args: dict = {}, session: ASFSession = ASFSession()\n",
     "            ):\n",
     "        super().__init__(args, session)\n",
     "\n",
-    "        # unique property of MyCustomClass\n",
-    "        self.custom_properties = custom_properties\n",
-    "    \n",
+    "        # totaly unique property of MyCustomClass\n",
+    "        self.timestamp = datetime.now()\n",
+    "\n",
+    "    # _base_properties is a special dict of ASFProduct that maps keywords to granule UMM json\n",
+    "    # defining properties and their paths here in conjunction with `get_property_paths()` \n",
+    "    # will let you easily access them in the product's `properties` dictionary\n",
+    "    # see `ASFProduct.umm_get()` for explanation of pathing\n",
+    "    _base_properties = {\n",
+    "        # Most product types use `CENTER_ESA_FRAME` as the value for `frameNumber` (unlike S1 and ALOS, which use `FRAME_NUMBER`), \n",
+    "        # this creates a new `esaFrame` property so we have that value too\n",
+    "        'esaFrame': {'path': ['AdditionalAttributes', ('Name', 'CENTER_ESA_FRAME'), 'Values', 0], 'cast': try_parse_int}, #Sentinel and ALOS product alt for frameNumber (ESA_FRAME)\n",
+    "    }\n",
+    "\n",
+    "    \"\"\" Example umm that the above pathing would map to:\n",
+    "        'umm': {\n",
+    "            'AdditionalAttributes': [\n",
+    "                {\n",
+    "                    'Name': 'CENTER_ESA_FRAME',\n",
+    "                    \"Values\": ['1300'] \n",
+    "                },\n",
+    "                ...\n",
+    "            ],\n",
+    "            ...\n",
+    "        }\n",
+    "    \"\"\"\n",
+    "\n",
     "    # write custom methods\n",
     "    def as_umm_json(self) -> dict:\n",
     "        return { 'umm': self.umm, 'meta': self.meta }\n",
     "    \n",
-    "    # Override built in ASFProduct methods, like `geojson()`, `get_stack_opts()`, or `get_default_baseline_product_type()`\n",
+    "    # Or Override built in ASFProduct methods, like `geojson()`, `get_stack_opts()`, or `get_default_baseline_product_type()`\n",
+    "    \n",
+    "    # This override of `geojson()` includes the product's state vectors in the final geojson output, \n",
+    "    # along with a custom class field timestamp and what version of asf-search was used at runtime\n",
     "    def geojson(self) -> dict:\n",
-    "        output = {\n",
-    "            **super().geojson()\n",
-    "        }\n",
+    "        output = super().geojson()\n",
     "\n",
-    "        output['properties'] = {\n",
-    "            **output['properties'],\n",
-    "            'customProperties': self.custom_properties\n",
-    "        }\n",
-    "\n",
+    "        output['properties']['stateVectors'] = self.get_state_vectors()\n",
+    "        output['properties']['timestamp'] = str(self.timestamp)\n",
+    "        output['properties']['ASFSearchVersion'] = asf.__version__\n",
     "        return output\n",
     "    \n",
-    "    def get_stack_opts(self, opts: ASFSearchOptions = None) -> ASFSearchOptions:\n",
-    "        # use S1Product's stack opt already written functionality\n",
-    "        opts = super().get_stack_opts(opts)\n",
-    "\n",
-    "        # but use some new product type to build the stack instead of S1Product's default, \"SLC\"\n",
-    "        opts.processingLevel = self.get_default_baseline_product_type()\n",
-    "\n",
-    "        return opts\n",
-    "    \n",
+    "    # This method is used internally by `ASFProduct.translate_product()` \n",
+    "    # to traverse the granule UMM for each property's corresponding values\n",
     "    @staticmethod\n",
-    "    def get_default_baseline_product_type() -> Union[str, None]:\n",
-    "        \"\"\"\n",
-    "        Returns the product type to search for when building a baseline stack.\n",
-    "        \"\"\"\n",
-    "        return 'NEW_PRODUCT_TYPE'\n",
+    "    def get_property_paths() -> dict:\n",
+    "        return {\n",
+    "            **asf.S1Product.get_property_paths(),\n",
+    "            **MyCustomS1Subclass._base_properties\n",
+    "        }\n",
+    "    \n",
+    "    # This method normally stacks the current product\n",
+    "    # in this version we search for every SLC-BURST product that\n",
+    "    # overlaps the given area, and return a list of burst stacks\n",
+    "    def stack(self, \n",
+    "            opts: ASFSearchOptions = None,\n",
+    "            aoi: str = None,\n",
+    "            useSubclass: Type[asf.ASFProduct] = None):\n",
+    "        \n",
+    "        bursts = asf.search(\n",
+    "            groupID=self.properties['groupID'], \n",
+    "            processingLevel=asf.PRODUCT_TYPE.BURST,\n",
+    "            intersectsWith=aoi if aoi is not None else opts.intersectsWith\n",
+    "        )\n",
     "\n",
-    "customS1SubclassProduct = MyCustomS1Subclass({'umm': s1.umm, 'meta': s1.meta}, session=s1.session, custom_properties={'customProperty': 'This is a special property'})\n",
+    "        if len(bursts) == 0: # use default S1Product version if there's no SLC_BURST\n",
+    "            return super().stack(opts=opts, useSubclass=useSubclass)\n",
+    "        \n",
+    "        return [burst.stack(opts=opts) for burst in bursts]\n",
+    "\n",
+    "customS1SubclassProduct = MyCustomS1Subclass({'umm': s1.umm, 'meta': s1.meta}, session=s1.session)\n",
     "\n",
     "customS1SubclassProduct.geojson()"
    ]
@@ -212,8 +246,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Notice the `customProperties` field in the output from `geojson()`.\n",
-    "`get_stack_opts()` should also use S1Product's stack ops, but with `NEW_PRODUCT_TYPE` instead of `SLC`:"
+    "Notice the `customProperties` field in the output from `geojson()`."
    ]
   },
   {
@@ -222,7 +255,34 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(customS1SubclassProduct.get_stack_opts())"
+    "fairbanks_area = 'LINESTRING(-147.2885 64.7464,-147.733 64.8586,-148.1878 64.731)'\n",
+    "customStack = customS1SubclassProduct.stack(aoi=fairbanks_area)\n",
+    "customStack"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from typing import List\n",
+    "\n",
+    "def view_stack_of_stacks(stack_of_stacks: List):\n",
+    "    print(f'Found {len(stack_of_stacks)} SLC-BURST stacks over AOI, stack lengths:')\n",
+    "    for stack_idx, stack in enumerate(stack_of_stacks):\n",
+    "        print(f\"\\t{stack_idx+1}:\\t{len(stack)} SLC-BURSTs \\t(Full Burst ID: {stack[-1].properties['burst']['fullBurstID']})\")\n",
+    "\n",
+    "view_stack_of_stacks(customStack)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "compare_properties(s1, customS1SubclassProduct)"
    ]
   },
   {
@@ -240,23 +300,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "customSubclassStack = s1.stack(ASFProductSubclass=MyCustomS1Subclass)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "customSubclassStack"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Baseline search will now use your subclass's `get_stack_opts()` and `is_valid_reference()` methods, as well as the `baseline_type` and any property path overrides."
+    "opts = asf.ASFSearchOptions(intersectsWith=fairbanks_area) # our custom class will be able to use our aoi this way\n",
+    "\n",
+    "customSubclassStack = asf.stack_from_id('S1A_IW_SLC__1SDV_20231224T032123_20231224T032150_051791_064179_16F5-SLC', opts=opts, useSubclass=MyCustomS1Subclass)\n",
+    "\n",
+    "view_stack_of_stacks(customSubclassStack)"
    ]
   }
  ],
@@ -276,7 +324,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.18"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,

--- a/examples/Advanced-Custom-ASFProduct-Subclassing.ipynb
+++ b/examples/Advanced-Custom-ASFProduct-Subclassing.ipynb
@@ -154,8 +154,8 @@
    "outputs": [],
    "source": [
     "import copy\n",
-    "from typing import Type, Union\n",
-    "from asf_search import ASFSearchOptions, ASFSession\n",
+    "from typing import List, Type, Union, Dict\n",
+    "from asf_search import ASFSearchOptions, ASFSession, ASFSearchResults\n",
     "from asf_search.ASFSearchOptions import ASFSearchOptions\n",
     "from asf_search.CMR.translate import try_parse_int\n",
     "from datetime import datetime\n",
@@ -193,11 +193,12 @@
     "        }\n",
     "    \"\"\"\n",
     "\n",
-    "    # write custom methods\n",
+    "    # CUSTOM CLASS METHODS\n",
+    "    # Return\n",
     "    def as_umm_json(self) -> Dict:\n",
     "        return { 'umm': self.umm, 'meta': self.meta }\n",
     "    \n",
-    "    # Or Override built in ASFProduct methods, like `geojson()`, `get_stack_opts()`, or `get_default_baseline_product_type()`\n",
+    "    # CLASS OVERRIDE METHODS\n",
     "    \n",
     "    # This override of `geojson()` includes the product's state vectors in the final geojson output, \n",
     "    # along with a custom class field timestamp and what version of asf-search was used at runtime\n",
@@ -218,13 +219,16 @@
     "            **MyCustomS1Subclass._base_properties\n",
     "        }\n",
     "    \n",
-    "    # This method normally stacks the current product\n",
+    "    # ASFProduct.stack() normally stacks the current product\n",
     "    # in this version we search for every SLC-BURST product that\n",
-    "    # overlaps the given area, and return a list of burst stacks\n",
+    "    # overlaps the given area with the same source scene, \n",
+    "    # and return a list of burst stacks\n",
+    "    # if no bursts are found, we fall back to building a regular stack\n",
     "    def stack(self, \n",
-    "            opts: ASFSearchOptions = None,\n",
-    "            aoi: str = None,\n",
-    "            useSubclass: Type[asf.ASFProduct] = None):\n",
+    "                opts: ASFSearchOptions = None,\n",
+    "                useSubclass: Type[asf.ASFProduct] = None,\n",
+    "                aoi: str = None\n",
+    "            ) -> Union[ASFSearchResults, List[ASFSearchResults]]:\n",
     "        \n",
     "        bursts = asf.search(\n",
     "            groupID=self.properties['groupID'], \n",
@@ -232,7 +236,7 @@
     "            intersectsWith=aoi if aoi is not None else opts.intersectsWith\n",
     "        )\n",
     "\n",
-    "        if len(bursts) == 0: # use default S1Product version if there's no SLC_BURST\n",
+    "        if len(bursts) == 0: # build a regular stack of SLCs if there's no SLC-BURST\n",
     "            return super().stack(opts=opts, useSubclass=useSubclass)\n",
     "        \n",
     "        return [burst.stack(opts=opts) for burst in bursts]\n",
@@ -246,7 +250,17 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Notice the `customProperties` field in the output from `geojson()`."
+    "Notice the `timestamp`, `ASFSearchVersion`, `stateVectors`, and `esaFrame` fields in the output from `geojson()`.\n",
+    "Below is a comparison of properties between the built-in `S1Product` and our `customS1SubclassProduct`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "compare_properties(s1, customS1SubclassProduct)"
    ]
   },
   {
@@ -258,6 +272,14 @@
     "fairbanks_area = 'LINESTRING(-147.2885 64.7464,-147.733 64.8586,-148.1878 64.731)'\n",
     "customStack = customS1SubclassProduct.stack(aoi=fairbanks_area)\n",
     "customStack"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Notice instead of a stack of `MyCustomS1Subclass` products we have a list of `S1BURSTProduct` stacks!\n",
+    "Below is a breakdown of this list of stacks:"
    ]
   },
   {
@@ -274,15 +296,6 @@
     "        print(f\"\\t{stack_idx+1}:\\t{len(stack)} SLC-BURSTs \\t(Full Burst ID: {stack[-1].properties['burst']['fullBurstID']})\")\n",
     "\n",
     "view_stack_of_stacks(customStack)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "compare_properties(s1, customS1SubclassProduct)"
    ]
   },
   {

--- a/examples/Advanced-Custom-ASFProduct-Subclassing.ipynb
+++ b/examples/Advanced-Custom-ASFProduct-Subclassing.ipynb
@@ -224,6 +224,40 @@
    "source": [
     "print(customS1SubclassProduct.get_stack_opts())"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Using Custom `ASFProduct` Subclasses in Baseline Search\n",
+    "\n",
+    "There may be instances where you want to build a spatio-temporal baseline stack from a reference of a custom subclass. `stack_from_id()` and `ASFProduct.stack()` support this via the `ASFProductSubclass` keyword."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "customSubclassStack = s1.stack(ASFProductSubclass=MyCustomS1Subclass)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "customSubclassStack"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Baseline search will now use your subclass's `get_stack_opts()` and `is_valid_reference()` methods, as well as the `baseline_type` and any property path overrides."
+   ]
   }
  ],
  "metadata": {
@@ -242,7 +276,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.8.18"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
- Adds `useSubclass` param to baseline search methods, converts reference and stack search results to given `ASFProduct` subclass prior to baseline stacking operations