### PR TITLE
Unwrapped WKT for BBOX, Dataset+Platform Keyword Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 -->
 ------
+## [v7.0.5](https://github.com/asfadmin/Discovery-asf_search/compare/v7.0.4...v7.0.5)
+### Fixed
+- Use unwrapped wkt when rectangular AOI provided for bbox calculation
+
+------
 ## [v7.0.4](https://github.com/asfadmin/Discovery-asf_search/compare/v7.0.3...v7.0.4)
 ### Changed
 - `OPERA-S1-CALIBRATION` dataset is now the `OPERA-S1-CALVAL` dataset, uses the `OPERA_S1_CALVAL` constant

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,9 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ------
 ## [v7.0.5](https://github.com/asfadmin/Discovery-asf_search/compare/v7.0.4...v7.0.5)
 ### Fixed
-- Use unwrapped wkt when rectangular AOI provided for bbox calculation
+- Unwrapped WKT used in bounding box calculation when searching rectangular AOI
+### Changed
+- `dataset` and `platform` search keywords can now be used at the same time
 
 ------
 ## [v7.0.4](https://github.com/asfadmin/Discovery-asf_search/compare/v7.0.3...v7.0.4)

--- a/asf_search/WKT/validate_wkt.py
+++ b/asf_search/WKT/validate_wkt.py
@@ -11,7 +11,7 @@ from .RepairEntry import RepairEntry
 from asf_search.exceptions import ASFWKTError
 
 
-def validate_wkt(aoi: Union[str, BaseGeometry]) -> Tuple[BaseGeometry, List[RepairEntry]]:
+def validate_wkt(aoi: Union[str, BaseGeometry]) -> Tuple[BaseGeometry, BaseGeometry, List[RepairEntry]]:
     """
     Param aoi: the WKT string or Shapely Geometry to validate and prepare for the CMR query
     Validates the given area of interest, and returns a validated and simplified WKT string
@@ -52,7 +52,7 @@ def _search_wkt_prep(shape: BaseGeometry):
     if isinstance(shape, Polygon):
         return orient(Polygon(shape.exterior), sign=1.0)
 
-def _simplify_geometry(geometry: BaseGeometry) -> Tuple[BaseGeometry, List[RepairEntry]]:
+def _simplify_geometry(geometry: BaseGeometry) -> Tuple[BaseGeometry, BaseGeometry, List[RepairEntry]]:
     """
     param geometry: AOI Shapely Geometry to be prepped for CMR 
     prepares geometry for CMR by:

--- a/tests/ASFSearchResults/test_ASFSearchResults.py
+++ b/tests/ASFSearchResults/test_ASFSearchResults.py
@@ -182,4 +182,7 @@ def run_test_ASFSearchResults_intersection(wkt: str):
                 product_geom_wrapped, product_geom_unwrapped, _ = asf.validate_wkt(shape(product.geometry))
                 original_shape = unchanged_aoi
 
-                assert overlap_check(product_geom_wrapped, wrapped) or overlap_check(product_geom_wrapped, original_shape), f"OVERLAP FAIL: {product.properties['sceneName']}, {product.geometry} \nproduct: {product_geom_wrapped.wkt} \naoi: {wrapped.wkt}"
+                if asf.translate.should_use_bbox(original_shape):
+                    assert overlap_check(product_geom_unwrapped, unwrapped) or overlap_check(product_geom_unwrapped, original_shape), f"OVERLAP FAIL: {product.properties['sceneName']}, {product.geometry} \nproduct: {product_geom_wrapped.wkt} \naoi: {wrapped.wkt}"
+                else:
+                    assert overlap_check(product_geom_wrapped, wrapped) or overlap_check(product_geom_wrapped, original_shape), f"OVERLAP FAIL: {product.properties['sceneName']}, {product.geometry} \nproduct: {product_geom_wrapped.wkt} \naoi: {wrapped.wkt}"


### PR DESCRIPTION
- Use unwrapped WKT for rectangular AOIs
- Enables Dataset & Platform keyword at the same time (this will be required for selecting subtypes in Vertex)