### PR TITLE
ASFSession Hidden/Restricted Dataset Access Normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,15 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 -->
 ------
+## [v7.0.9](https://github.com/asfadmin/Discovery-asf_search/compare/v7.0.8...v7.0.9)
+### Added
+- Improved logging in `ASFSession` authentication methods
+
+### Changed
+- `ASFSession` now allows for authorized user access to hidden/restricted CMR datasets via `auth_with_creds()` or `auth_with_cookiejar()` authentication methods (previously only supported via `auth_with_token()` method)
+- `ASFSession.auth_with_token()` now authenticates directly against EDL endpoint
+
+------
 ## [v7.0.8](https://github.com/asfadmin/Discovery-asf_search/compare/v7.0.7...v7.0.8)
 ### Added
 - `s3Urls` property added to `S1Product`, `OPERAS1Product`, and `NISARProduct` types, exposing direct access S3 links

--- a/asf_search/ASFSession.py
+++ b/asf_search/ASFSession.py
@@ -1,5 +1,5 @@
 import platform
-from typing import Dict, List, Union
+from typing import Dict, List
 import requests
 from requests.utils import get_netrc_auth
 import http.cookiejar
@@ -167,7 +167,7 @@ class ASFSession(requests.Session):
 
         return self
 
-    def _check_auth_cookies(self, cookies: Union[http.cookiejar.CookieJar, Dict]) -> bool:
+    def _check_auth_cookies(self, cookies: Dict) -> bool:
         return any(cookie in self.auth_cookie_names for cookie in cookies)
 
     def rebuild_auth(self, prepared_request: requests.Request, response: requests.Response):

--- a/asf_search/ASFSession.py
+++ b/asf_search/ASFSession.py
@@ -1,5 +1,5 @@
 import platform
-from typing import Dict, List
+from typing import Dict, List, Union
 import requests
 from requests.utils import get_netrc_auth
 import http.cookiejar
@@ -141,7 +141,7 @@ class ASFSession(requests.Session):
     def _update_edl_token(self, token: str):
         self.headers.update({'Authorization': 'Bearer {0}'.format(token)})
     
-    def auth_with_cookiejar(self, cookies: http.cookiejar.CookieJar):
+    def auth_with_cookiejar(self, cookies: Union[http.cookiejar.CookieJar, requests.cookies.RequestsCookieJar]):
         """
         Authenticates the session using a pre-existing cookiejar
 
@@ -149,8 +149,7 @@ class ASFSession(requests.Session):
 
         :return ASFSession: returns self for convenience
         """
-        
-        if not self._check_auth_cookies(dict(cookies)):
+        if not self._check_auth_cookies(cookies):
             raise ASFAuthenticationError("Cookiejar does not contain login cookies")
 
         for cookie in cookies:
@@ -167,7 +166,10 @@ class ASFSession(requests.Session):
 
         return self
 
-    def _check_auth_cookies(self, cookies: Dict) -> bool:
+    def _check_auth_cookies(self, cookies: Union[http.cookiejar.CookieJar, requests.cookies.RequestsCookieJar]) -> bool:
+        if isinstance(cookies, requests.cookies.RequestsCookieJar):
+            cookies = dict(cookies)
+
         return any(cookie in self.auth_cookie_names for cookie in cookies)
 
     def rebuild_auth(self, prepared_request: requests.Request, response: requests.Response):

--- a/tests/ASFSession/test_ASFSession.py
+++ b/tests/ASFSession/test_ASFSession.py
@@ -28,8 +28,13 @@ def run_auth_with_cookiejar(cookies: List):
     cookiejar = http.cookiejar.CookieJar()
     for cookie in cookies:
         cookiejar.set_cookie(create_cookie(name=cookie.pop('name'), **cookie))
+
+    # requests.cookies.RequestsCookieJar, which has slightly different behaviour
     session = ASFSession()
-    session.auth_with_cookiejar(cookies)
+    session.auth_with_cookiejar(cookiejar)
+
+    request_cookiejar_session = ASFSession()
+    request_cookiejar_session.auth_with_cookiejar(session.cookies)
 
 def run_test_asf_session_rebuild_auth(
     original_domain: str, 

--- a/tests/ASFSession/test_ASFSession.py
+++ b/tests/ASFSession/test_ASFSession.py
@@ -16,7 +16,7 @@ def run_auth_with_creds(username: str, password: str):
 def run_auth_with_token(token: str):
     session = ASFSession()
 
-    with patch('asf_search.ASFSession.get') as mock_token_session:
+    with patch('asf_search.ASFSession.post') as mock_token_session:
         if not token.startswith('Bearer EDL'):
                 mock_token_session.return_value.status_code = 400
                 session.auth_with_token(token)
@@ -43,7 +43,7 @@ def run_test_asf_session_rebuild_auth(
 
     session = ASFSession()
 
-    with patch('asf_search.ASFSession.get') as mock_token_session:
+    with patch('asf_search.ASFSession.post') as mock_token_session:
         mock_token_session.return_value.status_code = 200
         session.auth_with_token("bad_token")
         


### PR DESCRIPTION
### Added
- Improved logging in `ASFSession` authentication methods

### Changed
- `ASFSession` now allows for authorized user access to hidden/restricted CMR datasets via `auth_with_creds()` or `auth_with_cookiejar()` authentication methods (previously only supported via `auth_with_token()` method)
- `ASFSession.auth_with_token()` now authenticates directly against EDL endpoint