### PR TITLE
`ciso8601` Result Date Parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 -->
 ------
+## [v7.0.11](https://github.com/asfadmin/Discovery-asf_search/compare/v7.0.10...v7.0.11)
+### Changed
+- Uses `ciso8601` module for parsing dates from CMR response, significant performance improvement post-query
+
+------
 ## [v7.0.10](https://github.com/asfadmin/Discovery-asf_search/compare/v7.0.9...v7.0.10)
 ### Added
 - Improved logging in `ASFSession` authentication methods

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,16 +26,12 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 -->
 ------
-## [v7.0.11](https://github.com/asfadmin/Discovery-asf_search/compare/v7.0.10...v7.0.11)
-### Changed
-- Uses `ciso8601` module for parsing dates from CMR response, significant performance improvement post-query
-
-------
-## [v7.0.10](https://github.com/asfadmin/Discovery-asf_search/compare/v7.0.9...v7.0.10)
+## [v7.1.0](https://github.com/asfadmin/Discovery-asf_search/compare/v7.0.9...v7.1.0)
 ### Added
 - Improved logging in `ASFSession` authentication methods
 
 ### Changed
+- Uses `ciso8601` module for parsing dates from CMR response, significant performance improvement post-query
 - `ASFSession` now allows for authorized user access to hidden/restricted CMR datasets via `auth_with_creds()` or `auth_with_cookiejar()` authentication methods (previously only supported via `auth_with_token()` method)
 - `ASFSession.auth_with_token()` now authenticates directly against EDL endpoint
 

--- a/asf_search/CMR/translate.py
+++ b/asf_search/CMR/translate.py
@@ -10,6 +10,7 @@ from shapely.geometry.base import BaseGeometry
 from .field_map import field_map
 from .datasets import collections_per_platform
 import dateparser
+import ciso8601
 import logging
 
 
@@ -157,8 +158,11 @@ def try_parse_date(value: str) -> Optional[str]:
     if value is None:
         return None
 
-    date = dateparser.parse(value)
-
+    try:
+        date = ciso8601.parse_datetime(value)
+    except ValueError:
+        return None
+    
     if date is None:
         return value
 

--- a/asf_search/CMR/translate.py
+++ b/asf_search/CMR/translate.py
@@ -9,7 +9,6 @@ from shapely.geometry import Polygon
 from shapely.geometry.base import BaseGeometry
 from .field_map import field_map
 from .datasets import collections_per_platform
-import dateparser
 import ciso8601
 import logging
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,8 @@ requirements = [
     "importlib_metadata",
     "numpy",
     "dateparser",
-    "tenacity == 8.2.2"
+    "tenacity == 8.2.2",
+    "ciso8601"
 ]
 
 test_requirements = [

--- a/tests/ASFSearchResults/test_ASFSearchResults.py
+++ b/tests/ASFSearchResults/test_ASFSearchResults.py
@@ -1,6 +1,5 @@
 from typing import Dict, List
 
-import dateparser
 import asf_search as asf
 from asf_search import ASFSearchResults
 import defusedxml.ElementTree as DefusedETree


### PR DESCRIPTION
- uses `ciso8601` for umm result date parsing
- bumps from patch to minor version for release