### PR TITLE
ciso8601 in baseline stacking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 -->
 ------
+## [v7.1.1](https://github.com/asfadmin/Discovery-asf_search/compare/v7.1.0...v7.1.1)
+### Changed
+- Uses `ciso8601.parse_datetime()` in baseline calculations, speeds up calculations on larger stacks
+
+------
 ## [v7.1.0](https://github.com/asfadmin/Discovery-asf_search/compare/v7.0.9...v7.1.0)
 ### Added
 - Improved logging in `ASFSession` authentication methods

--- a/asf_search/baseline/calc.py
+++ b/asf_search/baseline/calc.py
@@ -2,7 +2,7 @@ from math import sqrt, cos, sin, radians
 from typing import List
 
 import numpy as np
-from dateutil.parser import parse
+from ciso8601 import parse_datetime
 
 from asf_search import ASFProduct
 # WGS84 constants
@@ -23,17 +23,17 @@ def calculate_perpendicular_baselines(reference: str, stack: List[ASFProduct]):
             baselineProperties['noStateVectors'] = True
             continue
 
-        asc_node_time = parse(baselineProperties['ascendingNodeTime']).timestamp()
+        asc_node_time = parse_datetime(baselineProperties['ascendingNodeTime']).timestamp()
 
-        start = parse(product.properties['startTime']).timestamp()
-        end = parse(product.properties['stopTime']).timestamp()
+        start = parse_datetime(product.properties['startTime']).timestamp()
+        end = parse_datetime(product.properties['stopTime']).timestamp()
         center = start + ((end - start) / 2)
         baselineProperties['relative_start_time'] = start - asc_node_time
         baselineProperties['relative_center_time'] = center - asc_node_time
         baselineProperties['relative_end_time'] = end - asc_node_time
 
-        t_pre = parse(positionProperties['prePositionTime']).timestamp()
-        t_post = parse(positionProperties['postPositionTime']).timestamp()
+        t_pre = parse_datetime(positionProperties['prePositionTime']).timestamp()
+        t_post = parse_datetime(positionProperties['postPositionTime']).timestamp()
         product.baseline['relative_sv_pre_time'] = t_pre - asc_node_time
         product.baseline['relative_sv_post_time'] = t_post - asc_node_time
 

--- a/asf_search/baseline/stack.py
+++ b/asf_search/baseline/stack.py
@@ -1,5 +1,5 @@
 from typing import Tuple, List
-from dateutil.parser import parse
+from ciso8601 import parse_datetime
 import pytz
 
 from .calc import calculate_perpendicular_baselines
@@ -66,12 +66,12 @@ def calculate_temporal_baselines(reference: ASFProduct, stack: ASFSearchResults)
     :param stack: The stack to operate on.
     :return: None, as the operation occurs in-place on the stack provided.
     """
-    reference_time = parse(reference.properties['startTime'])
+    reference_time = parse_datetime(reference.properties['startTime'])
     if reference_time.tzinfo is None:
         reference_time = pytz.utc.localize(reference_time)
 
     for secondary in stack:
-        secondary_time = parse(secondary.properties['startTime'])
+        secondary_time = parse_datetime(secondary.properties['startTime'])
         if secondary_time.tzinfo is None:
             secondary_time = pytz.utc.localize(secondary_time)
         secondary.properties['temporalBaseline'] = (secondary_time.date() - reference_time.date()).days

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,6 @@ from setuptools import find_packages, setup
 requirements = [
     "requests",
     "shapely",
-    "python-dateutil",
     "pytz",
     "importlib_metadata",
     "numpy",


### PR DESCRIPTION
- Uses `ciso8601.parse_datetime()` in baseline calculations, speeds up calculations on larger stacks