### PR TITLE
`OPERAS1Product` PGE V2.0.1 Subclassing Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,13 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 -->
 ------
+## [v7.1.2](https://github.com/asfadmin/Discovery-asf_search/compare/v7.1.0...v7.1.1)
+### Fixed
+- `OPERAS1Product` subclass now properly assigned to PGE v2.0.1 results
+### Changed
+- `ARIAS1GUNWProduct.is_ARIAS1GUNWProduct()` removed, replaced with `ASFProduct._is_subclass()` implementation
+
+------
 ## [v7.1.1](https://github.com/asfadmin/Discovery-asf_search/compare/v7.1.0...v7.1.1)
 ### Changed
 - Uses `ciso8601.parse_datetime()` in baseline calculations, speeds up calculations on larger stacks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 -->
 ------
-## [v7.1.2](https://github.com/asfadmin/Discovery-asf_search/compare/v7.1.0...v7.1.1)
+## [v7.1.2](https://github.com/asfadmin/Discovery-asf_search/compare/v7.1.1...v7.1.2)
 ### Fixed
 - `OPERAS1Product` subclass now properly assigned to PGE v2.0.1 results
 ### Changed

--- a/asf_search/ASFProduct.py
+++ b/asf_search/ASFProduct.py
@@ -424,3 +424,14 @@ class ASFProduct:
             return f(v)
         except TypeError:
             return None
+
+    @staticmethod
+    def _is_subclass(item: Dict) -> bool:
+        """
+        Used to determine which subclass to use for specific edge-cases when parsing results in search methods
+        (Currently implemented for ARIA and OPERA subclasses).
+
+        params:
+        - item (dict): the CMR UMM-G item to read from
+        """
+        raise NotImplementedError()

--- a/asf_search/Products/ARIAS1GUNWProduct.py
+++ b/asf_search/Products/ARIAS1GUNWProduct.py
@@ -58,7 +58,7 @@ class ARIAS1GUNWProduct(S1Product):
         return None
 
     @staticmethod
-    def is_ARIAS1GUNWProduct(item: Dict) -> bool:
+    def _is_subclass(item: Dict) -> bool:
         platform = ASFProduct.umm_get(item['umm'], 'Platforms', 0, 'ShortName')
         if platform in ['SENTINEL-1A', 'SENTINEL-1B']:
             asf_platform = ASFProduct.umm_get(item['umm'], 'AdditionalAttributes', ('Name', 'ASF_PLATFORM'), 'Values', 0)

--- a/asf_search/Products/OPERAS1Product.py
+++ b/asf_search/Products/OPERAS1Product.py
@@ -19,6 +19,8 @@ class OPERAS1Product(S1Product):
         'polarization': {'path': ['AdditionalAttributes', ('Name', 'POLARIZATION'), 'Values']} # dual polarization is in list rather than a 'VV+VH' style format
     }
 
+    _subclass_concept_ids = { 'C1257995185-ASF', 'C1257995186-ASF', 'C1258354200-ASF', 'C1258354201-ASF', 'C1259974840-ASF', 'C1259976861-ASF', 'C1259981910-ASF', 'C1259982010-ASF', 'C2777436413-ASF', 'C2777443834-ASF', 'C2795135174-ASF', 'C2795135668-ASF','C1260721853-ASF', 'C1260721945-ASF', 'C2803501097-ASF', 'C2803501758-ASF' }
+
     def __init__(self, args: Dict = {}, session: ASFSession = ASFSession()):
         super().__init__(args, session)
 
@@ -78,3 +80,10 @@ class OPERAS1Product(S1Product):
             return (self._read_property('validityStartDate', ''), keys[1])
 
         return keys
+
+    @staticmethod
+    def _is_subclass(item: Dict) -> bool:
+        # not all umm products have this field set, 
+        # but when it's available it's convenient for fast matching
+        concept_id = item['meta'].get('collection-concept-id')
+        return concept_id in OPERAS1Product._subclass_concept_ids

--- a/asf_search/search/baseline_search.py
+++ b/asf_search/search/baseline_search.py
@@ -52,7 +52,7 @@ def stack_from_product(
     stack.sort(key=lambda product: product.properties['temporalBaseline'])
 
     for warning in warnings:
-        ASF_LOGGER.warn(f'{warning}')
+        ASF_LOGGER.warning(f'{warning}')
     
     return stack
 

--- a/asf_search/search/search_generator.py
+++ b/asf_search/search/search_generator.py
@@ -266,6 +266,9 @@ def as_ASFProduct(item: Dict, session: ASFSession) -> ASFProduct:
 
     :returns the granule as an object of type ASFProduct
     """
+    if ASFProductType.OPERAS1Product._is_subclass(item):
+        return ASFProductType.OPERAS1Product(item, session=session)
+
     product_type_key = _get_product_type_key(item)
 
     # if there's a direct entry in our dataset to product type dict
@@ -283,7 +286,7 @@ def as_ASFProduct(item: Dict, session: ASFSession) -> ASFProduct:
 
     # If the platform exists, try to match it
     platform = _get_platform(item=item)
-    if ASFProductType.ARIAS1GUNWProduct.is_ARIAS1GUNWProduct(item=item):
+    if ASFProductType.ARIAS1GUNWProduct._is_subclass(item=item):
         return dataset_to_product_types.get('ARIA S1 GUNW')(item, session=session)
     elif (subclass := dataset_to_product_types.get(platform)) is not None:
         return subclass(item, session=session)
@@ -306,10 +309,10 @@ def _get_product_type_key(item: Dict) -> str:
     collection_shortName = ASFProduct.umm_get(item['umm'], 'CollectionReference', 'ShortName')
 
     if collection_shortName is None:
-        platform = _get_platform(item=item)
-        if ASFProductType.ARIAS1GUNWProduct.is_ARIAS1GUNWProduct(item=item):
+        if ASFProductType.ARIAS1GUNWProduct._is_subclass(item=item):
             return 'ARIA S1 GUNW'
 
+        platform = _get_platform(item=item)
         return platform
 
     return collection_shortName


### PR DESCRIPTION
- `OPERAS1Product` now assigned to results by checking meta `collection-concept-id` field
- Adds `_is_subclass()` static method to `ASFProduct`, to be implemented and called for edge-cases with subclassing behavior (may be used for all subclass matching in the future)