### PR TITLE
Fix for python 3.12, escape characters throw warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 -->
 ------
+## [v7.1.4](https://github.com/asfadmin/Discovery-asf_search/compare/v7.1.3...v7.1.4)
+### Fixed
+- Fixes syntax warning with escaped slash in `translate.py`
+
+------
 ## [v7.1.3](https://github.com/asfadmin/Discovery-asf_search/compare/v7.1.2...v7.1.3)
 ### Fixed
 - Adds missing values for polarization constants `DUAL_HH`, `DUAL_VV`, `DUAL_HV`, `DUAL_VH`, `HH_3SCAN`, `HH_4SCAN`, `HH_5SCAN`

--- a/asf_search/CMR/translate.py
+++ b/asf_search/CMR/translate.py
@@ -22,7 +22,7 @@ def translate_opts(opts: ASFSearchOptions) -> List:
     # intersectsWith, temporal, and other keys you don't want to escape, so keep whitelist instead
     for escape_commas in ["campaign"]:
         if escape_commas in dict_opts:
-            dict_opts[escape_commas] = dict_opts[escape_commas].replace(",", "\,")
+            dict_opts[escape_commas] = dict_opts[escape_commas].replace(",", "\\,")
 
     # Special case to unravel WKT field a little for compatibility
     if "intersectsWith" in dict_opts:


### PR DESCRIPTION
From [Discovery Public](https://chat.asf.alaska.edu/asf/pl/snanijghqibhje4k3gdird44ey):

Second bullet on https://docs.python.org/3/whatsnew/3.12.html#other-language-changes

Python throws a warning on this line. Escaping the slash fixes it on 3.12.

```
>>> "\,"
<stdin>:1: SyntaxWarning: invalid escape sequence '\,'
'\\,'
>>> "\\,"
'\\,'
```

(Though they moved it from a DeprecationWarning to a SyntaxWarning. It might never become an error? This would silence the warning at least)