### PR TITLE
Fix attribute error when calling datetime.UTC

### DIFF
--- a/asf_search/CMR/translate.py
+++ b/asf_search/CMR/translate.py
@@ -202,7 +202,7 @@ def fix_date(fixed_params: Dict[str, Any]):
             fixed_params['start'] if 'start' in fixed_params else '1978-01-01T00:00:00Z'
         )
         fixed_params['end'] = (
-            fixed_params['end'] if 'end' in fixed_params else datetime.now(datetime.UTC).isoformat()
+            fixed_params['end'] if 'end' in fixed_params else datetime.now(timezone.utc).isoformat()
         )
         fixed_params['season'] = (
             ','.join(str(x) for x in fixed_params['season']) if 'season' in fixed_params else ''


### PR DESCRIPTION
Fixes a bug related to the calling of a non-existent `datetime` attribute. This has caused [workflows to fail in production ](https://github.com/ASFHyP3/hyp3-nasa-disasters/actions/runs/10559419513)so we'd appreciate if this could get a quick review!