### PR TITLE
do not always require importlib_metadata backport

### DIFF
--- a/asf_search/__init__.py
+++ b/asf_search/__init__.py
@@ -1,5 +1,8 @@
-# backport of importlib.metadata for python < 3.8
-from importlib_metadata import PackageNotFoundError, version
+try:
+    from importlib.metadata import PackageNotFoundError, version
+except ImportError:
+    # backport of importlib.metadata for python < 3.8
+    from importlib_metadata import PackageNotFoundError, version
 
 ## Setup logging now, so it's available if __version__ fails:
 import logging

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ requirements = [
     'requests',
     'shapely',
     'pytz',
-    'importlib_metadata',
+    'importlib_metadata; python_version < "3.8"',
     'numpy',
     'dateparser',
     'python-dateutil',


### PR DESCRIPTION
This makes the import hybridized. The best of both worlds.