### PR TITLE
Patch Release V8.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 -->
 ------
+## [v8.2.1](https://github.com/asfadmin/Discovery-asf_search/compare/v8.2.0...v8.2.1)
+### Changed
+- `ARIAS1GUNWProduct` uses `fileID` for `sceneName` if unpopulated
+
 ## [v8.2.0](https://github.com/asfadmin/Discovery-asf_search/compare/v8.1.4...v8.2.0)
 ### Added
 - Add `ALOS2Product`, `DATASET.ALOS_2` constant, and dataset concept-id aliases for ALOS-2 products

--- a/asf_search/Products/ARIAS1GUNWProduct.py
+++ b/asf_search/Products/ARIAS1GUNWProduct.py
@@ -33,6 +33,9 @@ class ARIAS1GUNWProduct(S1Product):
     def __init__(self, args: Dict = {}, session: ASFSession = ASFSession()):
         super().__init__(args, session)
         self.properties['orbit'] = [orbit['OrbitNumber'] for orbit in self.properties['orbit']]
+        
+        if self.properties.get("sceneName") is None:
+            self.properties["sceneName"] = self.properties["fileID"]
 
         urls = self.umm_get(self.umm, 'RelatedUrls', ('Type', [('USE SERVICE API', 'URL')]), 0)
 


### PR DESCRIPTION
## [v8.2.1](https://github.com/asfadmin/Discovery-asf_search/compare/v8.2.0...v8.2.1)
### Changed
- `ARIAS1GUNWProduct` uses `fileID` for `sceneName` if unpopulated