### PR TITLE
V8.3.0 Minor Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,18 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 -->
 ------
+## [v8.3.0](https://github.com/asfadmin/Discovery-asf_search/compare/v8.2.2...v8.3.0)
+### Changed
+- `search()` no longer raises error if results are incomplete
+- if `asf-search` receives an incomplete page from CMR, log as a warning and continue querying until results are exhausted
+
+### Fixed
+- `S1BurstProduct` No longer include null frame value in jsonlite outputs
+- `S1BurstProduct` includes `SizeMB` in jsonlite outputs
+- `ARIAVersion` now populated in jsonlite outputs
+- `absoluteOrbit` field supports lists in jsonlite outputs
+
+------
 ## [v8.2.3](https://github.com/asfadmin/Discovery-asf_search/compare/v8.2.2...v8.2.3)
 ### Fixed
 - Fix csv output for `ALOS2Product` type

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 -->
 ------
+## [v8.2.3](https://github.com/asfadmin/Discovery-asf_search/compare/v8.2.2...v8.2.3)
+### Fixed
+- Fix csv output for `ALOS2Product` type
+
+------
 ## [v8.2.2](https://github.com/asfadmin/Discovery-asf_search/compare/v8.2.1...v8.2.2)
 ### Added
 - Added `constants.PRODUCT_TYPE.DISP_S1` processing level constant, concept-ids added to `OPERA-S1` dataset constant

--- a/asf_search/Products/ALOS2Product.py
+++ b/asf_search/Products/ALOS2Product.py
@@ -48,7 +48,6 @@ class ALOS2Product(ASFStackableProduct):
 
     def __init__(self, args: Dict = {}, session: ASFSession = ASFSession()):
         super().__init__(args, session)
-        self.properties.pop('processingLevel')
         self.properties.pop('md5sum')
         self.properties.pop('granuleType')
 

--- a/asf_search/Products/S1BurstProduct.py
+++ b/asf_search/Products/S1BurstProduct.py
@@ -37,7 +37,7 @@ class S1BurstProduct(S1Product):
     def __init__(self, args: Dict = {}, session: ASFSession = ASFSession()):
         super().__init__(args, session)
         self.properties["sceneName"] = self.properties["fileID"]
-
+        self.properties.pop('frameNumber', None)
         # Gathers burst properties into `burst` specific dict
         # rather than properties dict to limit breaking changes
         self.properties["burst"] = {

--- a/asf_search/export/jsonlite2.py
+++ b/asf_search/export/jsonlite2.py
@@ -72,6 +72,7 @@ class JSONLite2StreamArray(JSONLiteStreamArray):
 
         if p.get('burst') is not None: # is a burst product
             result['s1b'] = p['burst']
+            result['f'] = None
 
         if p.get('opera') is not None:
             result['s1o'] = p['opera']
@@ -79,6 +80,9 @@ class JSONLite2StreamArray(JSONLiteStreamArray):
         if p.get('nisar') is not None:
             result['nsr'] = p['nisar']
         
+        if p.get('ariaVersion') is not None:
+            result['ariav'] = p.get('ariaVersion')
+    
         return result
 
     def getOutputType(self) -> str:

--- a/asf_search/search/error_reporting.py
+++ b/asf_search/search/error_reporting.py
@@ -1,7 +1,7 @@
-from asf_search import ASFSearchOptions
+from asf_search import ASF_LOGGER, ASFSearchOptions
 from asf_search import INTERNAL
 import requests
-import logging
+
 
 
 def report_search_error(search_options: ASFSearchOptions, message: str):
@@ -10,7 +10,7 @@ def report_search_error(search_options: ASFSearchOptions, message: str):
     from asf_search import REPORT_ERRORS
 
     if not REPORT_ERRORS:
-        logging.warning(
+        ASF_LOGGER.error.warning(
             'Automatic search error reporting is turned off,'
             'search errors will NOT be reported to ASF.'
             '\nTo enable automatic error reporting, set asf_search.REPORT_ERRORS to True'
@@ -33,14 +33,14 @@ def report_search_error(search_options: ASFSearchOptions, message: str):
     try:
         response.raise_for_status()
     except requests.exceptions.HTTPError:
-        logging.error(
+        ASF_LOGGER.error(
             'asf-search failed to automatically report an error,'
             'if you have any questions email uso@asf.alaska.edu'
             f"\nError Text: HTTP {response.status_code}: {response.json()['errors']}"
         )
         return
     if response.status_code == 200:
-        logging.error(
+        ASF_LOGGER.error(
             (
                 'The asf-search module ecountered an error with CMR,'
                 'and the following message was automatically reported to ASF:'

--- a/asf_search/search/search.py
+++ b/asf_search/search/search.py
@@ -5,6 +5,7 @@ import datetime
 
 from asf_search import ASF_LOGGER, ASFSearchResults
 from asf_search.ASFSearchOptions import ASFSearchOptions
+from asf_search.exceptions import ASFSearchError
 from asf_search.search.search_generator import search_generator
 
 
@@ -183,7 +184,15 @@ def search(
         results.searchOptions = page.searchOptions
         perf = time.time()
 
-    results.raise_if_incomplete()
+
+    if not results.searchComplete:
+        msg = (
+            'Results may be incomplete due to a search error. '
+            'See ASF_LOGGER logging for more details.'
+        )
+
+        ASF_LOGGER.error(msg)
+        
 
     try:
         results.sort(key=lambda p: p.get_sort_keys(), reverse=True)

--- a/asf_search/search/search_generator.py
+++ b/asf_search/search/search_generator.py
@@ -240,22 +240,24 @@ def search_generator(
                 items, subquery_max_results, cmr_search_after_header = query_cmr(
                     opts.session, url, translated_opts, subquery_count
                 )
-            except (ASFSearchError, CMRIncompleteError) as exc:
+            except ASFSearchError as exc:
                 message = str(exc)
                 ASF_LOGGER.error(message)
                 report_search_error(query, message)
                 opts.session.headers.pop('CMR-Search-After', None)
-                # If it's a CMRIncompleteError, we can just stop here and return what we have
-                # It's up to the user to call .raise_if_incomplete() if they're using the
-                # generator directly.
-                if isinstance(exc, CMRIncompleteError):
-                    return
-                else:
-                    raise
+                raise
 
             ASF_LOGGER.debug(
                 f'SUBQUERY {subquery_idx + 1}: Page {page_number} fetched, returned {len(items)} items.'
             )
+
+            if len(items) != INTERNAL.CMR_PAGE_SIZE and len(items) + subquery_count < subquery_max_results:
+                message = 'CMR returned page of incomplete results.' \
+                f'Expected {min(INTERNAL.CMR_PAGE_SIZE, subquery_max_results - subquery_count)} results,' \
+                f'got {len(items)}'
+                ASF_LOGGER.warning(message)
+                report_search_error(query, message)
+            
             opts.session.headers.update({'CMR-Search-After': cmr_search_after_header})
             perf = time.time()
             last_page = process_page(
@@ -306,12 +308,12 @@ def query_cmr(
     # 9-10 per process
     # 3.9-5 per process
     # sometimes CMR returns results with the wrong page size
-    if len(items) != INTERNAL.CMR_PAGE_SIZE and len(items) + sub_query_count < hits:
-        raise CMRIncompleteError(
-            'CMR returned page of incomplete results.'
-            f'Expected {min(INTERNAL.CMR_PAGE_SIZE, hits - sub_query_count)} results,'
-            f'got {len(items)}'
-        )
+    # if len(items) != INTERNAL.CMR_PAGE_SIZE and len(items) + sub_query_count < hits:
+    #     raise CMRIncompleteError(
+    #         'CMR returned page of incomplete results.'
+    #         f'Expected {min(INTERNAL.CMR_PAGE_SIZE, hits - sub_query_count)} results,'
+    #         f'got {len(items)}'
+    #     )
 
     return items, hits, response.headers.get('CMR-Search-After', None)
 

--- a/tests/yml_tests/test_search.yml
+++ b/tests/yml_tests/test_search.yml
@@ -658,7 +658,7 @@ tests:
       params:
         processingLevel: CSLC-STATIC
 
-  - test-aliasing-search-against-api OERA-S1 RTC:
+  - test-aliasing-search-against-api OPERA-S1 RTC:
       params:
         dataset: OPERA-S1
         processingLevel: RTC


### PR DESCRIPTION
## [v8.3.0](https://github.com/asfadmin/Discovery-asf_search/compare/v8.2.2...v8.3.0)
### Changed
- `search()` no longer raises error if results are incomplete
- if `asf-search` receives an incomplete page from CMR, log as a warning and continue querying until results are exhausted

### Fixed
- `S1BurstProduct` No longer include null frame value in jsonlite outputs
- `S1BurstProduct` includes `SizeMB` in jsonlite outputs
- `ARIAVersion` now populated in jsonlite outputs
- `absoluteOrbit` field supports lists in jsonlite outputs