### PR TITLE
`ASFSession.auth_with_creds()` now checks EDL `/find_or_create_token` Endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 -->
 ------
+## [v9.0.0](https://github.com/asfadmin/Discovery-asf_search/compare/v8.3.5...v9.0.0)
+### Added
+- `ASFSession.auth_with_creds()` now also queries Earth Data Login's `/find_or_create_token`. If successful, will set `Authorization` to use the returned EDL bearer token, allowing authorized users to download restricted data they have access to from Earth Data Cloud like when authed with `auth_with_token()`. 
+- Added `EDL_HOST_UAT` and `CMR_HOST_UAT` to `constants.INTERNAL`
+
+------
 ## [v8.3.5](https://github.com/asfadmin/Discovery-asf_search/compare/v8.3.4...v8.3.5)
 ### Added
 - Added NISAR product type constants `L0B`, `RSLC`, `RIFG`, `RUNW`, `ROFF`, `GSLC`, `GCOV`, `GUNW`, `GOFF`, `SME2` to `constants.PRODUCT_TYPE`, supported for use with `processingLevel`.

--- a/asf_search/constants/INTERNAL.py
+++ b/asf_search/constants/INTERNAL.py
@@ -1,6 +1,7 @@
 ASF_AUTH_HOST = 'auth.asf.alaska.edu'
 
 CMR_HOST = 'cmr.earthdata.nasa.gov'
+CMR_HOST_UAT = 'cmr.uat.earthdata.nasa.gov'
 CMR_TIMEOUT = 30
 CMR_FORMAT_EXT = 'umm_json'
 CMR_GRANULE_PATH = f'/search/granules.{CMR_FORMAT_EXT}'
@@ -9,11 +10,13 @@ CMR_COLLECTIONS_PATH = f'{CMR_COLLECTIONS}.{CMR_FORMAT_EXT}'
 CMR_HEALTH_PATH = '/search/health'
 CMR_PAGE_SIZE = 250
 EDL_HOST = 'urs.earthdata.nasa.gov'
+EDL_HOST_UAT = f'uat.{EDL_HOST}'
+
 EDL_CLIENT_ID = 'BO_n7nTIlMljdvU6kRRB3g'
 
 DEFAULT_PROVIDER = 'ASF'
 
-AUTH_DOMAINS = ['asf.alaska.edu', 'earthdata.nasa.gov']
+AUTH_DOMAINS = ['asf.alaska.edu', 'earthdata.nasa.gov'] #, 'earthdatacloud.nasa.gov']
 AUTH_COOKIES = ['urs_user_already_logged', 'uat_urs_user_already_logged']
 
 ERROR_REPORTING_ENDPOINT = 'search-error-report.asf.alaska.edu'


### PR DESCRIPTION
add /find_or_create_token endpoint. Add UAT CMR/EDL endpoint constants