### PR TITLE
V9.0.7 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ------
 ## [v9.0.6](https://github.com/asfadmin/Discovery-asf_search/compare/v9.0.5...v9.0.6)
 ### Fixed
+- `json` output populates `relativeOrbit` field properly
+
+------
+## [v9.0.6](https://github.com/asfadmin/Discovery-asf_search/compare/v9.0.5...v9.0.6)
+### Fixed
 - Minor `json` output fixes
 
 ------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 -->
 ------
-## [v9.0.6](https://github.com/asfadmin/Discovery-asf_search/compare/v9.0.5...v9.0.6)
+## [v9.0.7](https://github.com/asfadmin/Discovery-asf_search/compare/v9.0.6...v9.0.7)
 ### Fixed
 - `json` output populates `relativeOrbit` field properly
 

--- a/asf_search/export/json.py
+++ b/asf_search/export/json.py
@@ -262,7 +262,7 @@ class JsonStreamArray(list):
             'processingTypeDisplay': p.get('processingTypeDisplay'),  #
             'productName': p.get('sceneName'),
             'product_file_id': p.get('fileID'),
-            'relativeOrbit': p.get('relativeOrbit'),
+            'relativeOrbit': p.get('pathNumber'),
             'sceneDate': p.get('sceneDate'),  #
             'sceneId': p.get('sceneName'),  #
             'sensor': p.get('sensor'),


### PR DESCRIPTION
## [v9.0.7](https://github.com/asfadmin/Discovery-asf_search/compare/v9.0.6...v9.0.7)
### Fixed
- `json` output populates `relativeOrbit` field properly
