### PR TITLE
Patch Release v9.0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [v9.0.9](https://github.com/asfadmin/Discovery-asf_search/compare/v9.0.8...v9.0.9)
 ### Added
 - Added NISAR L-SAR `RANGED_BANDWIDTH` constants `BW_20` and `BW_40`
+- Added NISAR `GSLC` and `GUNW` `processingLevel` collection aliases
 
 ------
 ## [v9.0.8](https://github.com/asfadmin/Discovery-asf_search/compare/v9.0.7...v9.0.8)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 -->
 ------
+## [v9.0.9](https://github.com/asfadmin/Discovery-asf_search/compare/v9.0.8...v9.0.9)
+### Added
+- Added NISAR L-SAR `RANGED_BANDWIDTH` constants `BW_20` and `BW_40`
+
+------
 ## [v9.0.8](https://github.com/asfadmin/Discovery-asf_search/compare/v9.0.7...v9.0.8)
 ### Changed
 - Changed certain NISAR collection aliases to reference latest concept-ids

--- a/asf_search/CMR/datasets.py
+++ b/asf_search/CMR/datasets.py
@@ -1692,6 +1692,34 @@ collections_by_processing_level = {
         'C1257349094-ASF',
         'C3622250865-ASF',
     ],
+    'GSLC': [
+        # 'NISAR_L2_GSLC_BETA_V1'
+        'C1261819167-ASFDEV',
+        'C1273831198-ASF',
+        'C2850259510-ASF',
+        # 'NISAR_L2_GSLC_PROVISIONAL_V1'
+        'C1261833024-ASFDEV',
+        'C1261833127-ASF',
+        'C2854332392-ASF',
+        # 'NISAR_L2_GSLC_V1'
+        'C1256413628-ASFDEV',
+        'C1257349102-ASF',
+        'C3622244601-ASF',
+    ],
+    'GUNW': [
+        # 'NISAR_L2_GUNW_BETA_V1':
+        'C1261819168-ASFDEV',
+        'C1261819270-ASF',
+        'C2850261892-ASF',
+        # 'NISAR_L2_GUNW_PROVISIONAL_V1'
+        'C1261833025-ASFDEV',
+        'C1261846741-ASF',
+        'C2854335566-ASF',
+        # 'NISAR_L2_GUNW_V1'
+        'C1256432264-ASFDEV',
+        'C1257349096-ASF',
+        'C3622247503-ASF',
+    ],
     'SME2': [
         'C1261819245-ASFDEV', # Beta
         'C1261819282-ASF',

--- a/asf_search/constants/RANGE_BANDWIDTH.py
+++ b/asf_search/constants/RANGE_BANDWIDTH.py
@@ -1,5 +1,7 @@
 # Nisar Sensor Bandwidths
 ## L-SAR
+BW_20 = "20"
+BW_40 = "40"
 BW_20_5 = "20+5"
 BW_40_5 = "40+5"
 BW_77 = "77"


### PR DESCRIPTION
## [v9.0.9](https://github.com/asfadmin/Discovery-asf_search/compare/v9.0.8...v9.0.9)
### Added
- Added NISAR L-SAR `RANGED_BANDWIDTH` constants `BW_20` and `BW_40`
- Added NISAR `GSLC` and `GUNW` `processingLevel` collection aliases
