### PR TITLE
feat: `get_nisar_orbit_ephemeras()` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 -->
 ------
 ## [v12.0.6](https://github.com/asfadmin/Discovery-asf_search/compare/v12.0.5...v12.0.6)
+### Added
+- `utils` module added as top level module
+    - `get_nisar_orbit_ephemeras()` method returns dictionary with latest `NISAR` `POE`, `MOE`, `NOE`, and `FOE` orbit ephemeras
+
 ### Fixed
 - Fix track based searches when `processingLevel` specified on `NISAR` dataset searches
 

--- a/asf_search/__init__.py
+++ b/asf_search/__init__.py
@@ -55,6 +55,7 @@ from .baseline import *  # noqa: F403 F401 E402
 from .WKT import validate_wkt  # noqa: F401 E402
 from .export import *  # noqa: F403 F401 E402
 from .Pair import Pair  # noqa:  F401, E402
+from . import utils # noqa: F401, E402
 
 REPORT_ERRORS = True
 """Enables automatic search error reporting to ASF, send any questions to uso@asf.alaska.edu"""

--- a/asf_search/utils/NISAR.py
+++ b/asf_search/utils/NISAR.py
@@ -1,0 +1,23 @@
+from asf_search.constants import PRODUCT_TYPE
+from asf_search.search import search
+from asf_search import ASFSearchOptions
+from copy import copy
+
+
+def get_nisar_orbit_ephemeras(opts: ASFSearchOptions | None = None):
+    """Returns a dictionary of the latest NISAR orbit ephemera products (`POE`, `MOE`, `NOE`, and `FOE`).
+    Additional options may be specified to pass to search.
+
+    For more information refer to the NISAR Data User Guide:
+    https://nisar-docs.asf.alaska.edu/orbit-ephemeris/#tbl-nisar-orbit-ephemeris-characteristics
+    """
+    opts = ASFSearchOptions() if opts is None else copy(opts)
+
+    opts.shortName = 'NISAR_OE'
+    opts.maxResults = 1
+
+    orbits = {}
+    for processingLevel in [PRODUCT_TYPE.POE, PRODUCT_TYPE.MOE, PRODUCT_TYPE.NOE, PRODUCT_TYPE.FOE]:
+        orbits[processingLevel] = search(opts=opts, processingLevel=processingLevel)[0]
+
+    return orbits

--- a/asf_search/utils/__init__.py
+++ b/asf_search/utils/__init__.py
@@ -1,0 +1,1 @@
+from .NISAR import get_nisar_orbit_ephemeras  # noqa: F401


### PR DESCRIPTION
### Added
- `utils` module added as top level module
    - `get_nisar_orbit_ephemeras()` method returns dictionary with latest `NISAR` `POE`, `MOE`, `NOE`, and `FOE` orbit ephemeras

