### PR TITLE
Patch Releast V12.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 -->
 ------
 ## [v12.0.6](https://github.com/asfadmin/Discovery-asf_search/compare/v12.0.5...v12.0.6)
+### Added
+- `utils` module added as top level module
+    - `get_nisar_orbit_ephemeras()` method returns dictionary with latest `NISAR` `POE`, `MOE`, `NOE`, and `FOE` orbit ephemeras
+
 ### Fixed
 - Fix track based searches when `processingLevel` specified on `NISAR` dataset searches
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,11 +26,17 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 -->
 ------
+## [v12.0.6](https://github.com/asfadmin/Discovery-asf_search/compare/v12.0.5...v12.0.6)
+### Fixed
+- Fix track based searches when `processingLevel` specified on `NISAR` dataset searches
+
+------
 ## [v12.0.5](https://github.com/asfadmin/Discovery-asf_search/compare/v12.0.4...v12.0.5)
 ### Added
 - DIST-ALERT-S1 product type to OPERA dataset
   - TileID searchable attribute
   - productVersion attribute
+
 ### Fixed
 - Fix edge-case with `platform` & `processingLevel` concept-id aliasing
 

--- a/asf_search/CMR/translate.py
+++ b/asf_search/CMR/translate.py
@@ -140,6 +140,7 @@ def fix_cmr_shapes(fixed_params: Dict[str, Any]) -> Dict[str, Any]:
 
 
 def should_use_asf_frame(cmr_opts):
+    # TODO: Investigate why this fails for NISAR when processing level specified
     asf_frame_platforms = ['SENTINEL-1A', 'SENTINEL-1B', 'SENTINEL-1C', 'ALOS', 'ALOS-2', 'NISAR', 'SEASAT 1']
 
     asf_frame_collections = get_concept_id_alias(asf_frame_platforms, collections_per_platform)

--- a/asf_search/CMR/translate.py
+++ b/asf_search/CMR/translate.py
@@ -16,14 +16,15 @@ try:
 except ImportError:
     from dateutil.parser import parse as parse_datetime
 
-
+nisar_collections_set = set(collections_per_platform['NISAR'])
 def translate_opts(opts: ASFSearchOptions) -> List:
     # Need to add params which ASFSearchOptions cant support (like temporal),
     # so use a dict to avoid the validate_params logic:
     dict_opts = dict(opts)
 
-    should_use_track = False
-    if dict_opts.get('processingLevel') is not None: # Certain products are now using PRODUCT_TYPE instead of PROCESSING_LEVEL
+    should_use_track = not set(dict_opts.get('collections', [])).isdisjoint(nisar_collections_set)
+
+    if not should_use_track and dict_opts.get('processingLevel') is not None: # Certain products are now using PRODUCT_TYPE instead of PROCESSING_LEVEL
         processingType = dict_opts.get('processingLevel', [])[0]
         if processingType in NISAR_PRODUCT_TYPES:
             should_use_track = True

--- a/asf_search/CMR/translate.py
+++ b/asf_search/CMR/translate.py
@@ -24,7 +24,7 @@ def translate_opts(opts: ASFSearchOptions) -> List:
 
     should_use_track = not set(dict_opts.get('collections', [])).isdisjoint(nisar_collections_set)
 
-    if not should_use_track and dict_opts.get('processingLevel') is not None: # Certain products are now using PRODUCT_TYPE instead of PROCESSING_LEVEL
+    if dict_opts.get('processingLevel') is not None: # Certain products are now using PRODUCT_TYPE instead of PROCESSING_LEVEL
         processingType = dict_opts.get('processingLevel', [])[0]
         if processingType in NISAR_PRODUCT_TYPES:
             should_use_track = True
@@ -140,7 +140,6 @@ def fix_cmr_shapes(fixed_params: Dict[str, Any]) -> Dict[str, Any]:
 
 
 def should_use_asf_frame(cmr_opts):
-    # TODO: Investigate why this fails for NISAR when processing level specified
     asf_frame_platforms = ['SENTINEL-1A', 'SENTINEL-1B', 'SENTINEL-1C', 'ALOS', 'ALOS-2', 'NISAR', 'SEASAT 1']
 
     asf_frame_collections = get_concept_id_alias(asf_frame_platforms, collections_per_platform)

--- a/asf_search/__init__.py
+++ b/asf_search/__init__.py
@@ -55,6 +55,7 @@ from .baseline import *  # noqa: F403 F401 E402
 from .WKT import validate_wkt  # noqa: F401 E402
 from .export import *  # noqa: F403 F401 E402
 from .Pair import Pair  # noqa:  F401, E402
+from . import utils # noqa: F401, E402
 
 REPORT_ERRORS = True
 """Enables automatic search error reporting to ASF, send any questions to uso@asf.alaska.edu"""

--- a/asf_search/utils/NISAR.py
+++ b/asf_search/utils/NISAR.py
@@ -1,0 +1,23 @@
+from asf_search.constants import PRODUCT_TYPE
+from asf_search.search import search
+from asf_search import ASFSearchOptions
+from copy import copy
+
+
+def get_nisar_orbit_ephemeras(opts: ASFSearchOptions | None = None):
+    """Returns a dictionary of the latest NISAR orbit ephemera products (`POE`, `MOE`, `NOE`, and `FOE`).
+    Additional options may be specified to pass to search.
+
+    For more information refer to the NISAR Data User Guide:
+    https://nisar-docs.asf.alaska.edu/orbit-ephemeris/#tbl-nisar-orbit-ephemeris-characteristics
+    """
+    opts = ASFSearchOptions() if opts is None else copy(opts)
+
+    opts.shortName = 'NISAR_OE'
+    opts.maxResults = 1
+
+    orbits = {}
+    for processingLevel in [PRODUCT_TYPE.POE, PRODUCT_TYPE.MOE, PRODUCT_TYPE.NOE, PRODUCT_TYPE.FOE]:
+        orbits[processingLevel] = search(opts=opts, processingLevel=processingLevel)[0]
+
+    return orbits

--- a/asf_search/utils/__init__.py
+++ b/asf_search/utils/__init__.py
@@ -1,0 +1,1 @@
+from .NISAR import get_nisar_orbit_ephemeras  # noqa: F401


### PR DESCRIPTION
## [v12.0.6](https://github.com/asfadmin/Discovery-asf_search/compare/v12.0.5...v12.0.6)
### Added
- `utils` module added as top level module
    - `get_nisar_orbit_ephemeras()` method returns dictionary with latest `NISAR` `POE`, `MOE`, `NOE`, and `FOE` orbit ephemeras

### Fixed
- Fix track based searches when `processingLevel` specified on `NISAR` dataset searches