### PR TITLE
Add file sizes to jsonlite2 output for Opera products

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 <!--
 ## Example template!!
 
-## [version](https://github.com/asfadmin/Discovery-PytestAutomation/compare/vOLD...vNEW)
+## [version](https://github.com/asfadmin/Discovery-asf_search/compare/vOLD...vNEW)
 
 ### Added:
 -
@@ -19,12 +19,17 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 -
 
 ### Fixed:
-- 
+-
 
 ### Removed:
 -
 
 -->
+------
+## [v12.1.1](https://github.com/asfadmin/Discovery-asf_search/compare/v12.1.0...v12.1.1)
+### Added
+- For Opera proudcts, add file size information to `jsonlite2` output
+
 ------
 ## [v12.1.0](https://github.com/asfadmin/Discovery-asf_search/compare/v12.0.7...v12.1.0)
 ### Added

--- a/asf_search/export/jsonlite.py
+++ b/asf_search/export/jsonlite.py
@@ -241,7 +241,8 @@ class JSONLiteStreamArray(list):
                 's3Urls': p.get('s3Urls', []),
                 'additionalUrls': p.get('additionalUrls'),
                 'tileID': p.get('tileID'),
-                'productVersion': p.get('productVersion')
+                'productVersion': p.get('productVersion'),
+                'bytes': p.get('bytes', {})
             }
             if p.get('validityStartDate'):
                 result['opera']['validityStartDate'] = p.get('validityStartDate')


### PR DESCRIPTION
## Purpose
Opera products are missing file sizes in vertex even though data is in cmr. Used in this [vertex pr](https://github.com/asfadmin/Discovery-SearchUI/pull/2569)

## Description
Add this data to jsonlite2 output

## Unit Tests
You have added unit tests to the test suite see the [README Testing section](https://github.com/asfadmin/Discovery-asf_search?tab=readme-ov-file#testing) for an overview on adding tests to the test suite.

## Target Merge Branch
Your pull request targets the `master` branch


***

### Checklist
- [ ] Purpose
- [ ] Description
- [ ] Snippet
- [ ] Error/Warning/Regression Free
- [ ] Unit Tests
- [ ] Target Merge Branch