### PR TITLE
Nisar geojson serializing over dateline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 -->
 
 ---
+## [v12.3.2](https://github.com/asfadmin/Discovery-asf_search/compare/v12.3.0...v12.3.1)
+
+### Fixed
+
+- `NISAR` dataset `geojson` export no longer fails when serializing coordinates for multipolygons
 
 ## [v12.3.1](https://github.com/asfadmin/Discovery-asf_search/compare/v12.3.0...v12.3.1)
 

--- a/asf_search/Products/NISARProduct.py
+++ b/asf_search/Products/NISARProduct.py
@@ -2,6 +2,7 @@ from shapely import unary_union, multipolygons
 from typing import Dict, Tuple, Union
 from asf_search import ASFSearchOptions, ASFSession, ASFStackableProduct
 from asf_search.CMR.translate import try_parse_frame_coverage, try_parse_bool, try_parse_int
+from asf_search.WKT.validate_wkt import _counter_clockwise_reorientation
 from shapely.geometry import shape, MultiPolygon
 from shapely.geometry.base import BaseGeometry
 from shapely.ops import transform
@@ -87,7 +88,7 @@ class NISARProduct(ASFStackableProduct):
             polygons = item['umm']['SpatialExtent']['HorizontalSpatialDomain']['Geometry'][
                 'GPolygons'
             ]
-            # dateline spanning scenes are stored as multiple polygons in CMR, 
+            # dateline spanning scenes are stored as multiple polygons in CMR,
             # we need to unwrap and merge them
             if len(polygons) > 1:
                 polygon_shapes = []
@@ -96,14 +97,13 @@ class NISARProduct(ASFStackableProduct):
                     geometry = self._get_unwrapped({'coordinates': [coordinates], 'type': 'Polygon'})
 
                     polygon_shapes.append(geometry)
-                
-                geom = unary_union(multipolygons(polygon_shapes))
 
+                geom = unary_union(multipolygons(polygon_shapes))
                 # sometimes the dateline spanning polygons don't overlap properly
                 if isinstance(geom, MultiPolygon):
                     geom = geom.convex_hull
-
-                return {'coordinates': [geom.exterior.coords], 'type': 'Polygon'}
+                geom, _warn = _counter_clockwise_reorientation(geom)
+                return {'coordinates': [", ".join(f"{x} {y}" for x, y in geom.exterior.coords)], 'type': 'Polygon'}
             else:
                 coordinates = polygons[0]['Boundary']['Points']
                 coordinates = [[c['Longitude'], c['Latitude']] for c in coordinates]


### PR DESCRIPTION
## Fixes
`NISAR` dataset `geojson` export no longer fails when serializing coordinates for multipolygons